### PR TITLE
Met à jour le statut de API Drone

### DIFF
--- a/_startup/api-drones.md
+++ b/_startup/api-drones.md
@@ -3,7 +3,7 @@ title: API Drones
 mission: Une meilleure connaissance du ciel pour plus de sécurité et d'innovation
 link: https://drone.beta.gouv.fr/
 repository: https://framagit.org/drone
-status: construction
+status: passation
 contact: yohan.boniface@data.gouv.fr
 start: 2017-06-01
 owner: SGDSN

--- a/_startup/api-drones.md
+++ b/_startup/api-drones.md
@@ -3,7 +3,7 @@ title: API Drones
 mission: Une meilleure connaissance du ciel pour plus de sécurité et d'innovation
 link: https://drone.beta.gouv.fr/
 repository: https://framagit.org/drone
-status: passation
+status: success
 contact: yohan.boniface@data.gouv.fr
 start: 2017-06-01
 owner: SGDSN


### PR DESCRIPTION
Lors du stand-up on à expliqué que API Drone a été passée, cette modification reflète cette réalité.
