### PR TITLE
Extract and decode templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Ajouter une Startup
 
-### [En un clic par l'interface web de GitHub](https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom-startup.md&value=---%0Atitle%3A%20Mes%20Aides%20%23%20une%20majuscule%20et%20pas%20d%27acronymes%0Amission%3A%20Acc%C3%A9der%20aux%20conseils%20d%27un%C2%B7e%20professionnel%C2%B7le%20%C3%A0%20proximit%C3%A9%20pour%20trouver%20un%20logement%20%23%20infinitif%2C%20pas%20de%20point%20%3B%20compl%C3%A9ter%20la%20phrase%20%C2%AB%20En%20investissant%20dans%20ce%20produit%20l%27%C3%89tat%20cherche%20%C3%A0%E2%80%A6%20%C2%BB%0Aowner%3A%20DINSIC%20%23%20Administration%20porteuse%0Astatus%3A%20consolidation%20%23%20les%20phases%20possibles%20sont%20d%C3%A9finies%20dans%20%5B%60_config.yml%60%5D(https%3A%2F%2Fgithub.com%2Fbetagouv%2Fbeta.gouv.fr%2Fblob%2Fmaster%2F_config.yml%23L29-L52)%0Astart%3A%202015-01-15%20%23%20date%20au%20format%20ISO%20(AAAA-MM-DD)%0Aend%3A%20%23%20laisser%20vide%0Alink%3A%20https%3A%2F%2Fmes-aides.gouv.fr%0Arepository%3A%20https%3A%2F%2Fgithub.com%2Fbetagouv%2Fmes-aides-ui%20%23%20ou%20page%20de%20description%20des%20d%C3%A9p%C3%B4ts%20s%27il%20y%20en%20a%20plusieurs%0Astats%3A%20false%0Acontact%3A%20contact%40mes-aides.gouv.fr%20%23%20sera%20visible%20de%20tous%0A---%0A%0A%23%23%20Fiche%20produit%0A%0ATexte%20libre%20au%20format%20%5BMarkdown%5D(http%3A%2F%2Fricostacruz.com%2Fcheatsheets%2Fmarkdown.html).%0A%0A%0A%23%23%20Rappels%0A%0A-%20%5B%20%5D%20Supprimer%20les%20commentaires%20dans%20le%20front-matter%20%3A%20supprimer%20les%20croisillons%20et%20le%20texte%20qui%20les%20suit%20dans%20la%20partie%20entre%20tirets%0A-%20%5B%20%5D%20Modifier%20le%20nom%20du%20fichier%20%60nom-startup.md%60%20dans%20le%20champ%20ci-dessus%20(attention%20%C3%A0%20bien%20inclure%20l%27extension%20%60.md%60)%0A-%20%5B%20%5D%20Assurez-vous%20que%20le%20fichier%20est%20bien%20dans%20le%20dossier%20%60%2F_startup%60%0A-%20%5B%20%5D%20Screenshot%20%3A%20ajouter%20une%20image%20en%201280x720px%20dans%20%2Fimg%2Fstartups%2F%24nom-startup.png%20(ou%20.jpg)%0A-%20%5B%20%5D%20Cr%C3%A9er%20une%20nouvelle%20branche%20pour%20l%27ajout%20de%20ce%20fichier%2C%20et%20la%20nommer%20du%20m%C3%AAme%20nom%20que%20le%20fichier%20%60nom-startup%60.%0A-%20%5B%20%5D%20Ouvrir%20une%20pull%20request%20pour%20valider%20l%27int%C3%A9gration.%0A-%20%5B%20%5D%20Effacer%20ce%20texte%20une%20fois%20que%20vous%20l%27avez%20lu%20%F0%9F%98%89)
+### [En un clic par l'interface web de GitHub](/trampoline.html?what=startup&where=_startup/nom-startup.md)
 
 Les illustrations doivent être en 16:9, au format 1280 ⨉ 720 pixels, optimisées au préalable avec un outil du type [ImageOptim](https://imageoptim.com/mac) - choisir des réglages "lossy" donnant en général plus de 50% de gains à la compression, mais ne pas supprimer les métadonnées d'images.
 
@@ -22,7 +22,7 @@ La documentation des différentes propriétés à renseigner est accessible en c
 
 ### 1. Écrire le billet
 
-[En un clic par l'interface web de GitHub](https://github.com/betagouv/beta.gouv.fr/new/master/_posts?filename=_posts/AAAA-MM-DD-titre.md&value=---%0d%0atitle%3a+Nom+du+billet%0d%0aauthors%3a+jean.dupont+%23+id+du+ou+des+auteurs%0d%0a---%0d%0a%0d%0aPour+ajouter+une+image+au+billet%2c+cr%c3%a9er+un+fichier+JPEG+dans+%60img%2fposts%60+du+m%c3%aame+nom+que+le+fichier+contenant+le+post.%0d%0a%0d%0a**Pensez+%c3%a0+modifier+le+nom+de+ce+fichier+%3a+il+doit+%c3%aatre+au+format+%60AAAA-MM-DD-titre.md%60+!**%0d%0aO%c3%b9+%60AAAA-MM-DD%60+est+la+date+%c3%a0+laquelle+vous+souhaitez+que+le+billet+soit+publi%c3%a9.) :smiley:
+[En un clic par l'interface web de GitHub](/trampoline.html?what=post&where=_posts/AAAA-MM-DD-titre.md) :smiley:
 
 Pour ajouter une image au billet, créer un fichier JPEG dans `img/posts` du même nom que le fichier contenant le post (donc par exemple `AAAA-MM-DD-titre.jpg`). À l'affichage, l'image sera redimensionnée : les dimensions exactes de l'image ont donc peu d'importance.
 
@@ -39,7 +39,7 @@ Recueillez l'avis d'au moins 2 membres de l'incubateur. Après de potentielles i
 
 ## Ajouter un événement
 
-### [En un clic par l'interface web de GitHub](https://github.com/betagouv/beta.gouv.fr/new/master/_posts?filename=_posts/AAAA-MM-DD-nom_evenement.md&value=---%0d%0atitle%3a+Nom+de+l%27%c3%a9v%c3%a9nement%0d%0acategory%3a+evenement%0d%0aregistration%3a+https%3a%2f%2feventbrite.com%2f%e2%80%a6+%23+URL+%c3%a0+laquelle+on+peut+s%27inscrire%0d%0alocation%3a+Palais+des+Congr%c3%a8s+de+Paris+%23+lieu+de+l%27%c3%a9v%c3%a9nement%0d%0astart%3a+2016-04-20T09%3a30%2b02%3a00++%23+date+de+d%c3%a9but+au+format+ISO%0d%0aend%3a+2016-04-20T17%3a30%2b02%3a00++%23+date+de+fin+au+format+ISO%0d%0a---%0d%0a%0d%0a%c3%89crire+ici+le+descriptif+de+l%27%c3%a9v%c3%a9nement.+Un+lien+d%27inscription+et+un+descriptif+des+horaires+sera+automatiquement+g%c3%a9n%c3%a9r%c3%a9%2c+ne+pas+l%27%c3%a9crire+ici.%0d%0a%0d%0aPour+ajouter+une+image+%c3%a0+l%27%c3%a9v%c3%a9nement%2c+cr%c3%a9er+un+fichier+JPEG+dans+%60img%2fposts%60+du+m%c3%aame+nom+que+le+fichier+contenant+le+post.%0d%0a%0d%0a**Pensez+%c3%a0+modifier+le+nom+de+ce+fichier+%3a+il+doit+%c3%aatre+au+format+%60AAAA-MM-DD-nom_evenement.md%60+!**%0d%0aO%c3%b9+%60AAAA-MM-DD%60+est+la+date+%c3%a0+laquelle+vous+souhaitez+que+l%27%c3%a9v%c3%a9nement+soit+annonc%c3%a9+sur+le+site+(et+non+la+date+de+l%27%c3%a9v%c3%a9nement+lui-m%c3%aame).) :smiley:
+### [En un clic par l'interface web de GitHub](/trampoline.html?what=event&where=_posts/AAAA-MM-DD-nom_evenement.md) :smiley:
 
 Un événement est un type de billet particulier. Il a donc quelques métadonnées supplémentaires (`start`, `end`…), mais est [équivalent](#publier-un-billet) pour le reste, dont l'ajout d'images et la création offline.
 
@@ -48,7 +48,7 @@ Notamment, attention, la date dans le nom du fichier au format `AAAA-MM-DD-nom_e
 
 ## Ajouter un membre à la communauté BetaGouv
 
-### [En un clic par l'interface web de GitHub](https://github.com/betagouv/beta.gouv.fr/new/master/_posts?filename=_authors/prenom.nom.md&value=---%0Afullname%3A%20Camille%20Dupont%20%23%20penser%20%C3%A0%20modifier%20le%20nom%20du%20fichier%20ci-dessus%20!%0Arole%3A%20Smartass%0A%23%20ci-dessous%2C%20tu%20peux%20aussi%20remplacer%20sgmap-bot%20par%20ton%20propre%20pseudo%20Github%0A%23%20ou%20bien%20fournir%20l%27URL%20(HTTPS%20obligatoire)%20d%27une%20image%20carr%C3%A9e%20512x512%20minimum%0A%23%20ou%20bien%20uploader%20un%20fichier%20JPG%20en%20512x512%20du%20m%C3%AAme%20nom%20que%20ce%20fichier%20dans%20%2Fimg%2Fauthors%20et%20effacer%20cette%20ligne%0Aavatar%3A%20https%3A%2F%2Favatars3.githubusercontent.com%2Fbetagouv-bot%3Fs%3D600%0Alink%3A%20%23%20optionnel%20%3A%20lien%20vers%20une%20page%20perso%20externe.%20Effacer%20cette%20ligne%20si%20rien%20%C3%A0%20mettre.%0Astart%3A%202016-12-31%20%23%20date%20d%27arriv%C3%A9e%20au%20format%20ISO%20(AAAA-MM-JJ)%0Aend%3A%202017-09-15%20%23%20date%20de%20fin%20de%20contrat%20au%20format%20ISO%20(AAAA-MM-JJ)%0Aemployer%3A%20%23%20dinsic%20ou%20independent%2F%3Cemployer%3E%20ou%20admin%2F%3Cemployer%3E%20ou%20service%2Focto%0A---%0A%0A%C3%89crit%20des%20autobiographies%20percutantes%20en%20moins%20de%20200%20caract%C3%A8res%20depuis%201972.) :smiley:
+### [En un clic par l'interface web de GitHub](/trampoline.html?what=author&where=_authors/prenom.nom.md) :smiley:
 
 Attention, l'image doit être carrée et de préférence à une résolution supérieure à 512 ⨉ 512 pixels, optimisée au préalable avec un outil du type [ImageOptim](https://imageoptim.com/mac) - choisir des réglages "lossy" donnant en général plus de 50% de gains à la compression, mais ne pas supprimer les métadonnées d'images.
 
@@ -59,7 +59,7 @@ Le nom du fichier est important : il doit correspondre au nom de la personne, s
 
 ## Ajouter une offre d'emploi
 
-### [En un clic par l'interface web de GitHub](https://github.com/betagouv/beta.gouv.fr/new/master/_posts?filename=_jobs/AAAA-MM-DD-nom_offre.md&value=---%0D%0Aroles%3A%20intitul%C3%A9%20du%2Fdes%20poste%2Fs%20%23%20un%C2%B7e%20d%C3%A9veloppeur%C2%B7e%2C%20deux%20business%20d%C3%A9veloppeur%C2%B7e%C2%B7s%2C%20un%C2%B7e%20d%C3%A9veloppeur%C2%B7e%20et%20une%20un%C2%B7e%20business%20d%C3%A9veloppeur%C2%B7e%2C%20etc.%0D%0Astartup%3A%20identifiant%20de%20la%20startup%20%20%23%20identifiant%20de%20la%20startup%20pour%20laquelle%20le%20recrutement%20est%20fait%20%3B%20cr%C3%A9er%20la%20startup%20si%20elle%20n%27existe%20pas%20encore%0D%0Atechno%3A%20Choix%20libre%20%23%20s%27il%20s%27agit%20d%27une%20offre%20dev%2C%20ajouter%20la%20techno%20ou%20expliciter%20que%20le%20choix%20est%20libre%C2%A0%3B%20enlever%20s%27il%20s%27agit%20d%27un%20autre%20type%20d%27offre%0D%0Ajunior%3A%20true%20%23%20S%27il%20est%20possible%20de%20candidater%20avec%20peu%20d%27exp%C3%A9rience%0D%0Aopen%3A%20true%20%23%20Basculer%20%C3%A0%20%27false%27%20ou%20supprimer%20une%20fois%20l%27offre%20pourvue%0D%0A---%0D%0A%0D%0A%C3%89crire%20ici%20le%20descriptif%20du%20poste.%20Attention%20%C3%A0%20la%20neutralit%C3%A9%20de%20genre%20%21%0D%0A%0D%0A%2A%2APensez%20%C3%A0%20modifier%20le%20nom%20de%20ce%20fichier%20%3A%20il%20doit%20%C3%AAtre%20au%20format%20%60AAAA-MM-DD-nom_offre.md%60%20%21%2A%2A%0D%0AO%C3%B9%20%60AAAA-MM-DD%60%20est%20la%20date%20%C3%A0%20laquelle%20vous%20souhaitez%20que%20l%27offre%20soit%20publi%C3%A9e.) :smiley:
+### [En un clic par l'interface web de GitHub](/trampoline.html?what=job&where=_jobs/AAAA-MM-DD-nom_offre.md) :smiley:
 
 > Une fois l'offre pourvue, bien penser à changer la valeur du flag `open` et de la mettre à `false`.
 
@@ -80,7 +80,7 @@ Mettre à jour la propriété `featured` de la phase correspondante pour référ
 
 ## Ajouter une page
 
-### [En un clic par l'interface web de GitHub](https://github.com/betagouv/beta.gouv.fr/new/master/_pages/fr?filename=page.html&value=---%0Apermalink%3A%20/page%0Alang%3A%20fr%0Aref%3A%20page%0A---) :smiley:
+### [En un clic par l'interface web de GitHub](/trampoline.html?what=page&where=_pages/page.html) :smiley:
 
 Attention, toutes les pages doivent avoir, dans leur [front matter](https://jekyllrb.com/docs/frontmatter/), les variables `permalink`, `lang` et `ref` définies.
 

--- a/templates/author.md
+++ b/templates/author.md
@@ -1,0 +1,14 @@
+---
+fullname: Camille Dupont # penser à modifier le nom du fichier ci-dessus !
+role: Smartass
+# ci-dessous, tu peux aussi remplacer sgmap-bot par ton propre pseudo Github
+# ou bien fournir l'URL (HTTPS obligatoire) d'une image carrée 512x512 minimum
+# ou bien uploader un fichier JPG en 512x512 du même nom que ce fichier dans /img/authors et effacer cette ligne
+avatar: https://avatars3.githubusercontent.com/betagouv-bot?s=600
+link: # optionnel : lien vers une page perso externe. Effacer cette ligne si rien à mettre.
+start: 2016-12-31 # date d'arrivée au format ISO (AAAA-MM-JJ)
+end: 2017-09-15 # date de fin de contrat au format ISO (AAAA-MM-JJ)
+employer: # dinsic ou independent/<employer> ou admin/<employer> ou service/octo
+---
+
+Écrit des autobiographies percutantes en moins de 200 caractères depuis 1972.

--- a/templates/event.md
+++ b/templates/event.md
@@ -1,0 +1,15 @@
+---
+title: Nom de l'événement
+category: evenement
+registration: https://eventbrite.com/… # URL à laquelle on peut s'inscrire
+location: Palais des Congrès de Paris # lieu de l'événement
+start: 2016-04-20T09:30+02:00  # date de début au format ISO
+end: 2016-04-20T17:30+02:00  # date de fin au format ISO
+---
+
+Écrire ici le descriptif de l'événement. Un lien d'inscription et un descriptif des horaires sera automatiquement généré, ne pas l'écrire ici.
+
+Pour ajouter une image à l'événement, créer un fichier JPEG dans `img/posts` du même nom que le fichier contenant le post.
+
+**Pensez à modifier le nom de ce fichier : il doit être au format `AAAA-MM-DD-nom_evenement.md` !**
+Où `AAAA-MM-DD` est la date à laquelle vous souhaitez que l'événement soit annoncé sur le site (et non la date de l'événement lui-même).

--- a/templates/job.md
+++ b/templates/job.md
@@ -1,0 +1,12 @@
+---
+roles: intitulé du/des poste/s # un·e développeur·e, deux business développeur·e·s, un·e développeur·e et une un·e business développeur·e, etc.
+startup: identifiant de la startup  # identifiant de la startup pour laquelle le recrutement est fait ; créer la startup si elle n'existe pas encore
+techno: Choix libre # s'il s'agit d'une offre dev, ajouter la techno ou expliciter que le choix est libre ; enlever s'il s'agit d'un autre type d'offre
+junior: true # S'il est possible de candidater avec peu d'expérience
+open: true # Basculer à 'false' ou supprimer une fois l'offre pourvue
+---
+
+Écrire ici le descriptif du poste. Attention à la neutralité de genre !
+
+**Pensez à modifier le nom de ce fichier : il doit être au format `AAAA-MM-DD-nom_offre.md` !**
+Où `AAAA-MM-DD` est la date à laquelle vous souhaitez que l'offre soit publiée.

--- a/templates/page.md
+++ b/templates/page.md
@@ -1,0 +1,5 @@
+---
+permalink: /page
+lang: fr
+ref: page
+---

--- a/templates/post.md
+++ b/templates/post.md
@@ -1,0 +1,9 @@
+---
+title: Nom du billet
+authors: jean.dupont # id du ou des auteurs
+---
+
+Pour ajouter une image au billet, créer un fichier JPEG dans `img/posts` du même nom que le fichier contenant le post.
+
+**Pensez à modifier le nom de ce fichier : il doit être au format `AAAA-MM-DD-titre.md` !**
+Où `AAAA-MM-DD` est la date à laquelle vous souhaitez que le billet soit publié.

--- a/templates/startup.md
+++ b/templates/startup.md
@@ -19,8 +19,9 @@ Texte libre au format [Markdown](http://ricostacruz.com/cheatsheets/markdown.htm
 ## Rappels
 
 - [ ] Supprimer les commentaires dans le front-matter : supprimer les croisillons et le texte qui les suit dans la partie entre tirets
-- [ ] Modifier le nom du fichier `nom_startup.md` dans le champ ci-dessus.
-- [ ] Screenshot : ajouter une image en 1280x720px dans /img/startups/$nom_startup.png (ou .jpg)
-- [ ] Créer une nouvelle branche pour l'ajout de ce fichier, et la nommer du même nom que le fichier `nom_startup`.
+- [ ] Modifier le nom du fichier `nom-startup.md` dans le champ ci-dessus (attention à bien inclure l'extension `.md`)
+- [ ] Assurez-vous que le fichier est bien dans le dossier `/_startup`
+- [ ] Screenshot : ajouter une image en 1280x720px dans /img/startups/$nom-startup.png (ou .jpg)
+- [ ] Créer une nouvelle branche pour l'ajout de ce fichier, et la nommer du même nom que le fichier `nom-startup`.
 - [ ] Ouvrir une pull request pour valider l'intégration.
 - [ ] Effacer ce texte une fois que vous l'avez lu 😉

--- a/templates/startup.md
+++ b/templates/startup.md
@@ -1,0 +1,26 @@
+---
+title: Mes Aides # une majuscule et pas d'acronymes
+mission: Accéder aux conseils d'un·e professionnel·le à proximité pour trouver un logement # infinitif, pas de point ; compléter la phrase « En investissant dans ce produit l'État cherche à… »
+owner: DINSIC # Administration porteuse
+status: consolidation # les phases possibles sont définies dans [`_config.yml`](https://github.com/betagouv/beta.gouv.fr/blob/master/_config.yml#L29-L52)
+start: 2015-01-15 # date au format ISO (AAAA-MM-DD)
+end: # laisser vide
+link: https://mes-aides.gouv.fr
+repository: https://github.com/betagouv/mes-aides-ui # ou page de description des dépôts s'il y en a plusieurs
+stats: false
+contact: contact@mes-aides.gouv.fr # sera visible de tous
+---
+
+## Fiche produit
+
+Texte libre au format [Markdown](http://ricostacruz.com/cheatsheets/markdown.html).
+
+
+## Rappels
+
+- [ ] Supprimer les commentaires dans le front-matter : supprimer les croisillons et le texte qui les suit dans la partie entre tirets
+- [ ] Modifier le nom du fichier `nom_startup.md` dans le champ ci-dessus.
+- [ ] Screenshot : ajouter une image en 1280x720px dans /img/startups/$nom_startup.png (ou .jpg)
+- [ ] Créer une nouvelle branche pour l'ajout de ce fichier, et la nommer du même nom que le fichier `nom_startup`.
+- [ ] Ouvrir une pull request pour valider l'intégration.
+- [ ] Effacer ce texte une fois que vous l'avez lu 😉

--- a/trampoline.html
+++ b/trampoline.html
@@ -1,16 +1,22 @@
 ---
 layout: null
 ---
-<script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,fetch"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.0/URI.js"></script>
-<script>
-  let templateUrl = "https://raw.githubusercontent.com/betagouv/beta.gouv.fr/decoded-templates/templates/startup.md"
-  let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom_startup.md&value="
-  fetch(templateUrl)
-    .then(response => response.text())
-    .then(body => {
-      let encoded = encodeURIComponent(body);
-      let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom_startup.md&value="+encoded
-      window.location = destination
-    })
-</script>
+<!DOCTYPE html>
+<html lang="fr">
+    <head></head>
+    <body>
+        <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,fetch"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.0/URI.js"></script>
+        <script>
+          let templateUrl = "https://raw.githubusercontent.com/betagouv/beta.gouv.fr/decoded-templates/templates/startup.md"
+          let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom_startup.md&value="
+          fetch(templateUrl)
+            .then(response => response.text())
+            .then(body => {
+              let encoded = encodeURIComponent(body);
+              let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom_startup.md&value="+encoded
+              window.location = destination
+            })
+        </script>
+    </body>
+</html>

--- a/trampoline.html
+++ b/trampoline.html
@@ -13,8 +13,8 @@ layout: null
           let where = params.where
           let templateUrl = "https://raw.githubusercontent.com/betagouv/beta.gouv.fr/templates/"+what+".md"
           fetch(templateUrl)
-            .then(response => response.text())
-            .then(body => {
+            .then(function(response) { return response.text()})
+            .then(function(body) {
               let encoded = encodeURIComponent(body);
               let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/?filename="+where+"&value="+encoded
               window.location = destination

--- a/trampoline.html
+++ b/trampoline.html
@@ -11,7 +11,7 @@ layout: null
           let params = new URI(window.location.href).query(true)
           let what = params.what
           let where = params.where
-          let templateUrl = "https://raw.githubusercontent.com/betagouv/beta.gouv.fr/decoded-templates/templates/"+what+".md"
+          let templateUrl = "https://raw.githubusercontent.com/betagouv/beta.gouv.fr/templates/"+what+".md"
           fetch(templateUrl)
             .then(response => response.text())
             .then(body => {

--- a/trampoline.html
+++ b/trampoline.html
@@ -1,0 +1,15 @@
+---
+layout: null
+---
+<script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.0/URI.js"></script>
+<script>
+  let templateUrl = "https://raw.githubusercontent.com/betagouv/beta.gouv.fr/decoded-templates/templates/startup.md"
+  let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom_startup.md&value="
+  fetch(templateUrl)
+    .then(response => response.text())
+    .then(text => {
+      let encoded = encodeURIComponent(body);
+      let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom_startup.md&value="+encoded
+      window.location = destination
+    })
+</script>

--- a/trampoline.html
+++ b/trampoline.html
@@ -7,7 +7,7 @@ layout: null
   let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom_startup.md&value="
   fetch(templateUrl)
     .then(response => response.text())
-    .then(text => {
+    .then(body => {
       let encoded = encodeURIComponent(body);
       let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom_startup.md&value="+encoded
       window.location = destination

--- a/trampoline.html
+++ b/trampoline.html
@@ -8,13 +8,15 @@ layout: null
         <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,fetch"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.0/URI.js"></script>
         <script>
-          let templateUrl = "https://raw.githubusercontent.com/betagouv/beta.gouv.fr/decoded-templates/templates/startup.md"
-          let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom_startup.md&value="
+          let params = new URI(window.location.href).query(true)
+          let what = params.what
+          let where = params.where
+          let templateUrl = "https://raw.githubusercontent.com/betagouv/beta.gouv.fr/decoded-templates/templates/"+what+".md"
           fetch(templateUrl)
             .then(response => response.text())
             .then(body => {
               let encoded = encodeURIComponent(body);
-              let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename=_startup/nom_startup.md&value="+encoded
+              let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename="+where+"&value="+encoded
               window.location = destination
             })
         </script>

--- a/trampoline.html
+++ b/trampoline.html
@@ -1,6 +1,7 @@
 ---
 layout: null
 ---
+<script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,fetch"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.0/URI.js"></script>
 <script>
   let templateUrl = "https://raw.githubusercontent.com/betagouv/beta.gouv.fr/decoded-templates/templates/startup.md"

--- a/trampoline.html
+++ b/trampoline.html
@@ -3,7 +3,7 @@ layout: null
 ---
 <!DOCTYPE html>
 <html lang="fr">
-    <head></head>
+    <head><title>Trampoline</title></head>
     <body>
         <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,fetch"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.0/URI.js"></script>

--- a/trampoline.html
+++ b/trampoline.html
@@ -16,7 +16,7 @@ layout: null
             .then(response => response.text())
             .then(body => {
               let encoded = encodeURIComponent(body);
-              let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/_startup?filename="+where+"&value="+encoded
+              let destination = "https://github.com/betagouv/beta.gouv.fr/new/master/?filename="+where+"&value="+encoded
               window.location = destination
             })
         </script>


### PR DESCRIPTION
Github permet passer un "template" lors de la création d'un nouveau fichier, sous la forme d'un paramètre GET. Cela nous a donné une chouette idée: intégrer dans `CONTRIBUTING.md` des liens rapides pour la création d'une nouvelle page startup, membre, job ou blog.

Par contre, la maintenance de ces templates n'est pas aisée. Pour modifier un template, on va dans `CONTRIBUTING.md` et on copie soigneusement une partie précise d'un lien Markdown (c'est chaud), puis on va sur urlencode.org ou dans son REPL préféré, on fait l'encodage du texte, et on revient dans `CONTRIBUTING.md` pour coller le texte encodé (donc devenu à peu près illisible) dans le lien Markdown (il faut aussi penser à préserver les parenthèses).

Cette façon de faire ne scale pas, est error-prone, et freine les évolutions des templates. (Les PR qui proposent une évolution des templates sont horribles à reviewer, pour ne pas dire impossibles.)

On va donc faire ça proprement en stockant les templates en clair et en utilisant un bout de code Javascript dans une page "trampoline" - tout ce qu'elle fait c'est de rediriger vers Github. On l'héberge sur beta.gouv.fr pour que tout reste au même endroit, sans dépendance externe.

Chemin d'implémentation:
- [x] extraire tous les templates
- [x] remplacer les liens dans CONTRIBUTING par des liens vers `/trampoline.html`
- [x] ajouter à chaque lien un paramètre identifiant le template et la destination: `/trampoline.html?what=startup&where=_startup/ma-startup.md` par exemple
- [x] dans `trampoline`, lire le paramètre identifiant le template demandé et l'exploiter
- [x] rendre `trampoline` HTML5 compliant
- [X] référencer les templates de la branche `master`