### PR TITLE
Accepte différentes valeurs pour le statut actif/inactif sur une startup

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -46,7 +46,11 @@
 
             {% if startup.first %}
                 {% capture currentId %}/startup/{{ startup.first[0] }}{% endcapture %}
-                {% assign isInactive = true %}
+                {% if startup.first[1] == "inactive" %}
+                    {% assign isInactive = true %}
+                {% else %}
+                    {% assign isInactive = false %}
+                {% endif %}
             {% else %}
                 {% capture currentId %}/startup/{{ startup }}{% endcapture %}
                 {% assign isInactive = false %}

--- a/_includes/startup-card.html
+++ b/_includes/startup-card.html
@@ -49,7 +49,11 @@
 
                 {% if startup.first %}
                     {% assign currentId = startup.first[0] %}
-                    {% assign isInactive = true %}
+                    {% if startup.first[1] == "inactive" %}
+                        {% assign isInactive = true %}
+                    {% else %}
+                        {% assign isInactive = false %}
+                    {% endif %}
                 {% else %}
                     {% assign currentId = startup %}
                     {% assign isInactive = false %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -90,7 +90,11 @@ layout: default
 
                             {% if startup.first %}
                                 {% capture currentId %}/startup/{{ startup.first[0] }}{% endcapture %}
-                                {% assign isInactive = true %}
+                                {% if startup.first[1] == "inactive" %}
+                                    {% assign isInactive = true %}
+                                {% else %}
+                                    {% assign isInactive = false %}
+                                {% endif %}
                             {% else %}
                                 {% capture currentId %}/startup/{{ startup }}{% endcapture %}
                                 {% assign isInactive = false %}


### PR DESCRIPTION
L'exemple ici https://github.com/betagouv/beta.gouv.fr/pull/1211 montre que la valeur `active` n'est pas considérée comme l'inverse de `inactive`, en effet dans le code on regarde si il y a une valeur, auquel cas on considère que cette valeur est forcément "inactive".

Cette PR rend le comportement plus intuitif à mon sens, en regardant si la valeur est bien `inactive` ou autre.

On pourrait écrire le code suivant que je trouve un peu trop cryptique mais je me demande quel est votre avis. Je ne sais pas non plus si cela marche avec Jekyll.
```js
{% assign isInactive = (startup.first[1] == "inactive") %}
```