### PR TITLE
Répare le graphe d'évolution des effectifs

### DIFF
--- a/_pages/fr/communaute.html
+++ b/_pages/fr/communaute.html
@@ -74,7 +74,7 @@ ref: community
     };
 
     {% for person in site.authors %}
-        var employerType = '{{ person.employer }}'.split('/')[0];
+        var employerType = '{{ person.employer | slugify }}'.split('-')[0];
 
         {% if person.start %}
             window.data[employerType].push({


### PR DESCRIPTION
Certaines PR récentes contenaient des fiches membres avec des mentions du type:
```
employer: admin/Ministère de l'ananas
````
La présence du caractère apostrophe a eu pour conséquence de casser le code Javascript qui construisait les données du graphes, à cause de [la ligne suivante](https://github.com/betagouv/beta.gouv.fr/blob/f7c63f640b97c558fdba40f47231d1824281f2aa/_pages/fr/communaute.html#L77):
```
        var employerType = '{{ person.employer }}'.split('/')[0];
```

Cette ligne, en construisant une chaîne Javascript à partir du champ `employer` , supposait implicitement que ce champ ne contiendrait jamais d'apostrophe. A l'exécution avec la valeur ci-dessus elle donne en effet ceci:
```
        var employerType = 'admin/Ministère de l'ananas'.split('/')[0];
```

Pour Javascript c'est OK jusqu'ici:
```
        var employerType = 'admin/Ministère de l'
```
mais ensuite il ne sait plus quoi en faire:
```
ananas'.split('/')[0];
```

Il suffit d'une seule apostrophe pour un seul des membres de la communauté pour faire planter tout le graphe, car l'erreur affecte le parsing de tout le bloc de code: le résultat est que le tableau `window.data` n'est pas construit du tout.

La seule solution est de supprimer les apostrophes en amont, dans le code Jekyll qui génère les lignes Javascript; c'est ce que fait ce commit.