### PR TITLE
Removed unused 'link' field

### DIFF
--- a/_authors/adrien.gonzalez.md
+++ b/_authors/adrien.gonzalez.md
@@ -2,7 +2,6 @@
 fullname: Adrien Gonzalez
 role: Développeur
 avatar: https://avatars3.githubusercontent.com/betagouv-bot?s=600
-link:
 start: 2018-02-12 
 end:  2018-06-01
 employer: independent


### PR DESCRIPTION
It is preferable to not leave a field unused.