### PR TITLE
Réparer les review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
     "name": "beta.gouv.fr",
     "scripts": {},
-    "env": {},
+    "env": {"CI":"true"},
     "formation": {},
     "addons": [],
     "buildpacks": [{


### PR DESCRIPTION
Une mise à jour récente de Github Pages fait que la version de Ruby utilisée par Heroku sur les anciennes stacks (`cedar-14`) ne permet plus de générer le site beta.gouv.fr. J'ai migré vers la stack `heroku-16` mais cela n'est pas suffisant, il faut également activer la variable d'environnement `CI` qui déclenche la lecture des versions courantes de Github Pages et en particulier de la version de Ruby utilisée en prod.

Cette PR renseigne donc simplement `CI=true` pour toutes les apps Heroku. Testé sur #1321.