### PR TITLE
Ajout docker-compose.yml et doc pour dev local

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,9 @@ Mettre à jour la propriété `featured` de la phase correspondante pour référ
 
 Attention, toutes les pages doivent avoir, dans leur [front matter](https://jekyllrb.com/docs/frontmatter/), les variables `permalink`, `lang` et `ref` définies.
 
-## Modifier la présentation du site
+## Modifier la présentation du site en Local
+
+### Utilisation de Jekyll pour le développement en local
 
 Ce site est construit avec [Jekyll](https://jekyllrb.com/), un générateur de sites statiques. La version utilisée est celle [actuellement en production](https://pages.github.com/versions/) sur GitHub Pages.
 
@@ -98,6 +100,10 @@ bundle exec jekyll serve
 ```
 
 Les fichiers pertinents pour une modification de la présentation sont probablement dans les dossiers `_layouts` et `css`.
+
+### Utilisation de Docker pour le développement en local
+- Installer (Docker](https://docs.docker.com/compose/install/) (Docker compose est normalement installé automatiquement avec Docker)
+- Lancer `docker-compose up`
 
 ### Dépendances : un `Gemfile` particulier
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,6 @@ Au vu du public visé, ce site doit être **dégradable** jusqu'à IE8.
 - Il expose une API des membres de la communauté : `https://beta.gouv.fr/api/v1/authors.json`.
 - Un _bot_ ou assistant automatique (dont le code est également [disponible](https://github.com/betagouv/betaGouvBot)) exploite cette API pour faciliter la gestion RH de l'Incubateur.
 
-## Développement
+## Contribution et développement
 
-### Lancement du site en développement local avec docker
-- Installer docker (Docker compose est normalement installé automatiquement avec Docker)
-- Lancer `docker-compose up`
-
-### Lancement du site en développement local avec Jekyll
-- Installer jekyll
-- Lancer `jekyll serve --incremental`
+Plus de détails ici : [CONTRIBUTING.md](https://github.com/betagouv/beta.gouv.fr/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -46,3 +46,13 @@ Au vu du public visé, ce site doit être **dégradable** jusqu'à IE8.
 
 - Il expose une API des membres de la communauté : `https://beta.gouv.fr/api/v1/authors.json`.
 - Un _bot_ ou assistant automatique (dont le code est également [disponible](https://github.com/betagouv/betaGouvBot)) exploite cette API pour faciliter la gestion RH de l'Incubateur.
+
+## Développement
+
+### Lancement du site en développement local avec docker
+- Installer docker (Docker compose est normalement installé automatiquement avec Docker)
+- Lancer `docker-compose up`
+
+### Lancement du site en développement local avec Jekyll
+- Installer jekyll
+- Lancer `jekyll serve --incremental`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  web:
+    image: jekyll/jekyll
+    command: jekyll serve --incremental
+    volumes:
+      - .:/srv/jekyll
+    ports:
+      - "4000:4000"


### PR DESCRIPTION
Permet le dev en local avec docker ou indique la commande jekyll pour développer avec un autorefresh.
