### PR TITLE
Rename le-bon-tuteur to e-mjpm

### DIFF
--- a/_authors/adrien.gonzalez.md
+++ b/_authors/adrien.gonzalez.md
@@ -7,5 +7,5 @@ start: 2018-02-12
 end:  2018-06-01
 employer: independent
 startups:
-  - le-bon-tuteur
+  - e-mjpm
 ---

--- a/_authors/jasmine.meurin.md
+++ b/_authors/jasmine.meurin.md
@@ -5,5 +5,5 @@ start: 2017-12-01
 end: 2018-06-30
 employer: admin/pole-emploi
 startups:
-    - le-bon-tuteur
+    - e-mjpm
 ---

--- a/_authors/lucie.delorme.md
+++ b/_authors/lucie.delorme.md
@@ -5,5 +5,5 @@ start: 2017-12-01
 end: 2018-06-30
 employer: admin/pole-emploi
 startups:
-    - le-bon-tuteur
+    - e-mjpm
 ---

--- a/_authors/maxime.basset.md
+++ b/_authors/maxime.basset.md
@@ -6,7 +6,7 @@ start: 2017-09-01
 employer: service/NUMA
 startups:
     - workinfrance
-    - le-bon-tuteur
+    - e-mjpm
 ---
 
 Harder Better Faster Stronger.

--- a/_startup/e-mjpm.md
+++ b/_startup/e-mjpm.md
@@ -1,6 +1,6 @@
 ---
-title: Le Bon Tuteur
-mission: Trouver le bon tuteur pour les personnes sous protection judiciaire
+title: e-MJPM
+mission: Nous simplifions l’attribution des mesures de protection juridique des majeurs
 owner: Ministère des Affaires sociales
 status: investigation
 start: 2017-10-26


### PR DESCRIPTION
Nous avons renommé la startup "Le Bon Tuteur" en "e-MJPM" et nous voulons refléter ce changement sur le site de beta.gouv.fr :

- Changement sur la fiche produit et les profils des porteurs.
- à venir : changement de l'URL + mail de contact