### PR TITLE
dans les startups associées : Locat.io -> Locatio (le filename a changé)

### DIFF
--- a/_incubator/mtes.md
+++ b/_incubator/mtes.md
@@ -11,7 +11,7 @@ startups:
   - aides-territoires
   - assec
   - camino
-  - locat-io
+  - locatio
 ---
 
 La Fabrique numérique, lancée en novembre 2017, a été ouverte à tous les agents de l’administration centrale, des directions régionales de l’environnement, de l’aménagement et du logement (DREAL), des directions inter-régionales de la mer (DIRM) et des directions interdépartementales des routes (DIR). Sa mission : accompagner, soutenir et porter les intrapreneurs des ministères en charge de l’écologie et des territoires.


### PR DESCRIPTION
Pour l'instant pas de référencement de locatio