### PR TITLE
Amélioration de l'accessibilité, corrections mineures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ bundle exec jekyll serve
 
 Les fichiers pertinents pour une modification de la présentation sont probablement dans les dossiers `_layouts` et `css`.
 
-### Utilisation de Docker pour le développement en local
+### Utilisation de Docker pour le développement en local
 - Installer (Docker](https://docs.docker.com/compose/install/) (Docker compose est normalement installé automatiquement avec Docker)
 - Lancer `docker-compose up`
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Au vu du public visé, ce site doit être **dégradable** jusqu'à IE8.
 - Il expose une API des membres de la communauté : `https://beta.gouv.fr/api/v1/authors.json`.
 - Un _bot_ ou assistant automatique (dont le code est également [disponible](https://github.com/betagouv/betaGouvBot)) exploite cette API pour faciliter la gestion RH de l'Incubateur.
 
-## Contribution et développement
+## Contribution et développement
 
 Plus de détails ici : [CONTRIBUTING.md](https://github.com/betagouv/beta.gouv.fr/blob/master/CONTRIBUTING.md)

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ twitter_id: 715451644683673601 # more stable than the username
 future: false
 
 # Plugins
-gems:
+plugins:
   - jekyll-redirect-from
 
 # Default author for blog posts, can be overridden in each post

--- a/_includes/subscribe.html
+++ b/_includes/subscribe.html
@@ -1,10 +1,10 @@
 <form method="post" action="https://app.mailjet.com/widget/iframe/1O2v/14x" id="newsletter">
-    <label for="subscribe-email" class="title">Abonnez-vous<br>pour recevoir nos annonces</label>
+    <label for="subscribe-email" class="title" aria-label="Renseignez votre adresse e-mail pour recevoir nos annonces">Abonnez-vous<br>pour recevoir nos annonces</label>
     <div class="input-container">
         <input required type="email" autocomplete="on" id="subscribe-email" name="w-field-field-4125-18987-430683-email" placeholder="votre@email.fr">
         <label class="icon">
-            <input id="subscribe" type="submit" class="submit-arrow" value="Submit">
-            <svg role="img" class="search-icon" width="18" height="15" viewBox="0 0 14 12">
+            <input id="subscribe" type="submit" class="submit-arrow" value="Recevoir nos annonces">
+            <svg aria-hidden="true" class="search-icon" width="18" height="15" viewBox="0 0 14 12">
                 <path class="arrow-vector" fill="#3C424F" fill-rule="evenodd" d="M120.828427,16.6568542 L111,16.6568542 L111,18.6568542 L120.828427,18.6568542 L117.585786,21.8994949 L119,23.3137085 L124.656854,17.6568542 L123.949747,16.9497475 L119,12 L117.585786,13.4142136 L120.828427,16.6568542 Z" transform="translate(-111 -12)"></path>
             </svg>
         </label>
@@ -12,14 +12,14 @@
 </form>
 
 <div class="social-links">
-    <a href="http://twitter.com/intent/follow?user_id=715451644683673601" title="Suivez nous sur Twitter">
-        <svg role="img" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414">
+    <a href="https://twitter.com/intent/follow?user_id=715451644683673601" aria-label="Suivez-nous sur Twitter">
+        <svg aria-hidden="true" role="img" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414">
             <path fill="#fff" d="M16 3.038c-.59.26-1.22.437-1.885.517.677-.407 1.198-1.05 1.443-1.816-.634.37-1.337.64-2.085.79-.598-.64-1.45-1.04-2.396-1.04-1.812 0-3.282 1.47-3.282 3.28 0 .26.03.51.085.75-2.728-.13-5.147-1.44-6.766-3.42C.83 2.58.67 3.14.67 3.75c0 1.14.58 2.143 1.46 2.732-.538-.017-1.045-.165-1.487-.41v.04c0 1.59 1.13 2.918 2.633 3.22-.276.074-.566.114-.865.114-.21 0-.41-.02-.61-.058.42 1.304 1.63 2.253 3.07 2.28-1.12.88-2.54 1.404-4.07 1.404-.26 0-.52-.015-.78-.045 1.46.93 3.18 1.474 5.04 1.474 6.04 0 9.34-5 9.34-9.33 0-.14 0-.28-.01-.42.64-.46 1.2-1.04 1.64-1.7z" fill-rule="nonzero"/>
         </svg>
         @BetaGouv
     </a>
-    <a href="https://github.com/betagouv" title="Consultez notre dépôt GitHub">
-        <svg role="img" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414">
+    <a href="https://github.com/betagouv" aria-label="Consultez notre dépôt GitHub">
+        <svg aria-hidden="true" role="img" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414">
             <path fill="#fff" d="M8 0C3.58 0 0 3.582 0 8c0 3.535 2.292 6.533 5.47 7.59.4.075.547-.172.547-.385 0-.19-.007-.693-.01-1.36-2.226.483-2.695-1.073-2.695-1.073-.364-.924-.89-1.17-.89-1.17-.725-.496.056-.486.056-.486.803.056 1.225.824 1.225.824.714 1.223 1.873.87 2.33.665.072-.517.278-.87.507-1.07-1.777-.2-3.644-.888-3.644-3.953 0-.873.31-1.587.823-2.147-.09-.202-.36-1.015.07-2.117 0 0 .67-.215 2.2.82.64-.178 1.32-.266 2-.27.68.004 1.36.092 2 .27 1.52-1.035 2.19-.82 2.19-.82.43 1.102.16 1.915.08 2.117.51.56.82 1.274.82 2.147 0 3.073-1.87 3.75-3.65 3.947.28.24.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.14.46.55.38C13.71 14.53 16 11.53 16 8c0-4.418-3.582-8-8-8"/>
         </svg>
         betagouv

--- a/_sass/subscribe.scss
+++ b/_sass/subscribe.scss
@@ -41,7 +41,11 @@
 }
 
 .subscribe form input[type=submit] {
-    display: none;
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
 }
 
 .subscribe form input[type=email] {


### PR DESCRIPTION
Bonjour,

Cette PR vise à améliorer l'accessibilité du formulaire d'abonnement aux annonces de beta.gouv.fr.
Le bouton de soumission du formulaire n'était pas exploitable par les utilisateurs de lecteurs d'écran à cause de la propriété CSS `display: none`, qui a été remplacée par d'autres règles CSS.

De plus, quelques erreurs orthographiques et typographiques ont été corrigées sur certains textes.