### PR TITLE
Améliore la présentation des infos sur chaque startup

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -22,10 +22,6 @@ layout: default
 
         <div class="content">
             <ul class="ui description text container">
-                <li>Le porteur administratif est {{ page.owner }}.</li>
-                {% assign incubator_id = page.incubator | prepend: '/incubateur/' %}
-                {% assign incubator = site.incubator | where:'id',incubator_id | first %}
-                <li>L'incubateur est <a href="{{ incubator.url }}" title="{{ incubator.title }}">{{ incubator.title }}</a>.</li>
                 <li>Le produit est <em>{{ status | strip }}</em>, il
                     {% if page.link %}
                         est disponible sur <a href="{{ page.link }}" title="{{ page.title }}">{{ page.link }}</a>.
@@ -33,15 +29,6 @@ layout: default
                         <em>n'est pas encore accessible au public.</em>
                     {% endif %}
                 </li>
-
-                <li>Le code source
-                    {% if page.repository %}
-                        <a href="{{ page.repository }}">est libre.</a>
-                    {% else %}
-                        <em>n'est pas encore ouvert.</em>
-                    {% endif %}
-                </li>
-
                 <li>Les statistiques d'usage
                     {% if page.stats %}
                         <a href="{{ page.link | strip }}/stats" title="Statistiques de {{ page.title }}">sont disponibles.</a>
@@ -49,7 +36,17 @@ layout: default
                         <em>ne sont pas encore disponibles.</em>
                     {% endif %}
                 </li>
-
+                <li>Le code source
+                    {% if page.repository %}
+                        <a href="{{ page.repository }}">est libre.</a>
+                    {% else %}
+                        <em>n'est pas encore ouvert.</em>
+                    {% endif %}
+                </li>
+                <li>Le porteur administratif est {{ page.owner }}.</li>
+                {% assign incubator_id = page.incubator | prepend: '/incubateur/' %}
+                {% assign incubator = site.incubator | where:'id',incubator_id | first %}
+                <li>L'incubateur est <a href="{{ incubator.url }}" title="{{ incubator.title }}">{{ incubator.title }}</a>.</li>
                 <li>
                     {% if page.contact %}
                         <a href="mailto:{{ page.contact }}?subject={{ page.title | uri_escape }}%20sur%20beta.gouv.fr">Contacter l’équipe</a>.

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -21,14 +21,14 @@ layout: default
         </div>
 
         <div class="content">
+            <p class="ui description text container">Le produit est <em>{{ status | strip }}</em>, il
+                {% if page.link %}
+                    est disponible sur <a href="{{ page.link }}" title="{{ page.title }}">{{ page.link }}</a>.
+                {% else %}
+                    <em>n'est pas encore accessible au public.</em>
+                {% endif %}
+            </p>
             <ul class="ui description text container">
-                <li>Le produit est <em>{{ status | strip }}</em>, il
-                    {% if page.link %}
-                        est disponible sur <a href="{{ page.link }}" title="{{ page.title }}">{{ page.link }}</a>.
-                    {% else %}
-                        <em>n'est pas encore accessible au public.</em>
-                    {% endif %}
-                </li>
                 <li>Les statistiques d'usage
                     {% if page.stats %}
                         <a href="{{ page.link | strip }}/stats" title="Statistiques de {{ page.title }}">sont disponibles.</a>

--- a/css/startup.css
+++ b/css/startup.css
@@ -9,7 +9,3 @@
 .card .startup-header {
     text-align: center;
 }
-
-.card .content .description li:nth-child(1) {
-    margin-bottom: 1em;
-}

--- a/css/startup.css
+++ b/css/startup.css
@@ -9,3 +9,7 @@
 .card .startup-header {
     text-align: center;
 }
+
+.card .content .description li:nth-child(1) {
+    margin-bottom: 1em;
+}


### PR DESCRIPTION
Fixes #1527

Avant:
![screen shot 2018-06-10 at 14 17 50](https://user-images.githubusercontent.com/216452/41201468-171e1f28-6cb9-11e8-97b6-b8aa6290ec15.png)

Après:
![screen shot 2018-06-10 at 14 18 12](https://user-images.githubusercontent.com/216452/41201478-235da164-6cb9-11e8-98ee-6b90035fcc05.png)

De haut en bas on va des informations les plus pertinentes au grand public, vers les informations les plus pertinentes en interne; à l'exception du "contactez-nous" qui reste en fin de liste.