### PR TITLE
pix: update repository url

### DIFF
--- a/_startup/pix.md
+++ b/_startup/pix.md
@@ -7,7 +7,7 @@ status: success
 start: 2016-06-08
 end:
 link: https://pix.beta.gouv.fr
-repository: https://github.com/betagouv/pix-live
+repository: https://github.com/1024pix/pix/
 stats: false
 contact: contact@pix.beta.gouv.fr
 ---


### PR DESCRIPTION
L'url du repo a changé et pas de lien ou redirection vers le nouveau depuis l'ancien repo :/
