### PR TITLE
Ré-écriture du résumé des phases de startup d'état

### DIFF
--- a/_pages/fr/index.html
+++ b/_pages/fr/index.html
@@ -38,10 +38,10 @@ title: Incubateur de services publics numériques
     <h2 class="ui divider horizontal">Phases d'une Startup d'État</h2>
 
     <ol class="ui container">
-        <li>Un agent public <strong>investigue une friction</strong> entre administration et citoyens.</li>
-        <li>Deux à quatre personnes <strong>construisent un produit</strong> numérique en moins de six mois.</li>
-        <li>L'équipe <strong>consolide le service</strong> en élargissant son public cible.</li>
-        <li>Un opérateur institutionnel <strong>reprend le service</strong> et assure sa pérennité.</li>
+        <li>Un agent public ou une administration <strong>identifie un problème de politique publique</strong>.</li>
+        <li>L’équipe <strong>lance une solution</strong> le plus rapidement possible et la teste auprès de premiers usagers.</li>
+        <li>L’équipe reçoit de quoi <strong>déployer le service sans cesser de l’améliorer</strong>, pour en accroître l’impact.</li>
+        <li>La Startup d’État devient un service public numérique national <strong>disponible pour tous les usagers</strong>.</li>
     </ol>
 
     <a href="communaute" class="primary success cta">Une communauté de {{ site.authors | size }} personnes&nbsp;&nbsp;➤</a>


### PR DESCRIPTION
Avant:
<img width="946" alt="screen shot 2018-06-13 at 15 55 20" src="https://user-images.githubusercontent.com/1475946/41355626-40d67642-6f22-11e8-9571-5e08a2f34e4a.png">

Après:
<img width="1131" alt="screen shot 2018-06-13 at 15 55 14" src="https://user-images.githubusercontent.com/1475946/41355627-40f4f540-6f22-11e8-87b6-e44e19a63bb7.png">


