### PR TITLE
Correction de l'affichage de la phase dans la fiche startup

### DIFF
--- a/_data/fr/phases.yml
+++ b/_data/fr/phases.yml
@@ -8,7 +8,6 @@ endgame:
   consolidation:
     name: en consolidation
   death:
-    singular: abandonné
-    name: abandonnées
+    name: abandonné
 investigation:
     name: en investigation

--- a/_data/fr/phases.yml
+++ b/_data/fr/phases.yml
@@ -8,6 +8,7 @@ endgame:
   consolidation:
     name: en consolidation
   death:
-    name: abandonné
+    name: abandonnées
+    singular: abandonné
 investigation:
     name: en investigation

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -4,8 +4,10 @@ layout: default
 {% capture status %}
     {% if site.data.fr.phases.incubation[page.status].name %}
         en {{ site.data.fr.phases.incubation[page.status].name }}
+    {% elsif site.data.fr.phases.endgame[page.status].name %}
+        {{ site.data.fr.phases.endgame[page.status].name }}
     {% else %}
-        {{ site.data.fr.phases.endgame[page.status].singular }}
+	{{ site.data.fr.phases.investigation.name }}
     {% endif %}
 {% endcapture %}
 <div class="ui container padded">

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -9,7 +9,7 @@ layout: default
     {% elsif site.data.fr.phases.endgame[page.status].name %}
         {{ site.data.fr.phases.endgame[page.status].name }}
     {% else %}
-	{{ site.data.fr.phases.investigation.name }}
+	    {{ site.data.fr.phases.investigation.name }}
     {% endif %}
 {% endcapture %}
 <div class="ui container padded">

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -4,6 +4,8 @@ layout: default
 {% capture status %}
     {% if site.data.fr.phases.incubation[page.status].name %}
         en {{ site.data.fr.phases.incubation[page.status].name }}
+    {% elsif site.data.fr.phases.endgame[page.status].singular %}
+        {{ site.data.fr.phases.endgame[page.status].singular }}
     {% elsif site.data.fr.phases.endgame[page.status].name %}
         {{ site.data.fr.phases.endgame[page.status].name }}
     {% else %}


### PR DESCRIPTION
Pour les phases "consolidation" et "investigation", le status ne s'affiche pas sur la page de startup : 
`Le produit est **missing information here**, il n'est pas encore accessible au public.`
Avant -> Après
![image](https://user-images.githubusercontent.com/1238254/41381776-88e7879a-6f69-11e8-9f90-9eb0233efd7b.png)
