### PR TITLE
Séparation plus claire entre les alumnis et les actifs

### DIFF
--- a/css/communaute.css
+++ b/css/communaute.css
@@ -8,7 +8,7 @@
 }
 
 #alumni ~ .author img {
-    filter: sepia(80%);
+    filter: sepia(70%);
 }
 
 #alumni ~ .author img:hover {

--- a/css/communaute.css
+++ b/css/communaute.css
@@ -8,9 +8,9 @@
 }
 
 #alumni ~ .author img {
-    filter: sepia(70%);
+    filter: grayscale(100%);
 }
 
 #alumni ~ .author img:hover {
-    filter: sepia(0%)
+    filter: grayscale(0%)
 }

--- a/css/communaute.css
+++ b/css/communaute.css
@@ -2,3 +2,15 @@
     position: relative;
     height: 60vh;
 }
+
+#alumni {
+    margin: 6em 0 2em;
+}
+
+#alumni ~ .author img {
+    filter: sepia(80%);
+}
+
+#alumni ~ .author img:hover {
+    filter: sepia(0%)
+}


### PR DESCRIPTION
Il y a tellement de cartes qu'on fait défiler tout ça à vitesse grand V, donc on loupe la séparation entre les deux catégories de cartes.
