### PR TITLE
Accélérer CI (Baser le cache sur Gemlock.lock)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,12 @@ jobs:
 
     steps:
       - checkout
+      - run:
+          name: Generate Gemlock
+          command: bundle lock
+            
       - restore_cache:
-          key: dependency-cache-{{ checksum "Gemfile" }}
+          key: dependency-cache-{{ checksum "Gemfile.lock" }}
 
       - run:
           name: Install Ruby dependencies
@@ -22,7 +26,7 @@ jobs:
             pip install --user --upgrade html5validator  # will install in $HOME/.local
 
       - save_cache:
-          key: dependency-cache-{{ checksum "Gemfile" }}
+          key: dependency-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - ./vendor/bundle
             - $HOME/.local


### PR DESCRIPTION
Il se pourrait que l'on puisse accélérer la CI de cette manière.

Générer le Gemfile coute 4s.
Avoir un cache de gem non à jour coûte 1 à 2 mins.