### PR TITLE
Add link to conventions

### DIFF
--- a/_includes/footer-nav-external.md
+++ b/_includes/footer-nav-external.md
@@ -1,3 +1,4 @@
 - [Une mission de la DINSIC](http://modernisation.gouv.fr)
 - [Améliorer cette page](https://github.com/betagouv/beta.gouv.fr/edit/master/{{ page.path }})
 - [Suivi d'audience et vie privée](/suivi)
+- [Conventions de partenariat](https://www.data.gouv.fr/fr/datasets/conventions-de-partenariat/)


### PR DESCRIPTION
Les conventions de délégation de gestion doivent être publiées pour être mise en oeuvre. À défault d'un bulletin ou journal officiel, je les ai mises sur [data.gouv.fr](https://www.data.gouv.fr/fr/datasets/conventions-de-partenariat/).

Cette PR ajoute un lien dans le footer pour y accéder facilement.