### PR TITLE
Utilise Python3 pour la validation HTML

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
           name: Install html5validator
           command: |
             sudo apt-get update
-            sudo apt-get install -y python-pip
-            pip install --user --upgrade html5validator  # will install in $HOME/.local
+            sudo apt-get install -y python3-pip
+            pip3 install --user --upgrade html5validator  # will install in $HOME/.local
 
       - save_cache:
           key: dependency-cache-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
Python 2.7 ne prend pas correctement en charge les encodages, avec pour résultat que html5validator échoue sur un message totalement cryptique dès lors que le nom d'un fichier à valider contient un caractère accentué.

Conclusion: on est en 2018, on est en France, alors si on utilise Python quelque part c'est Python 3.