### PR TITLE
Contre-mesure pour le bug d'affichage dans Chrome 69

### DIFF
--- a/_pages/fr/communaute.html
+++ b/_pages/fr/communaute.html
@@ -47,13 +47,13 @@ ref: community
 </section>
 
 <section class="ui four stackable doubling cards container">
-    <h2 class="ui divider horizontal">La communauté des Startups d'État</h2>
+    <h2 class="ui divider horizontal container">La communauté des Startups d'État</h2>
 
     {% include author.html description=page.hire_card %}
 
     {{ current_members_cards }}
 
-    <h2 id="alumni" class="ui divider horizontal">Les ancien·ne·s</h2>
+    <h2 id="alumni" class="ui divider horizontal container">Les ancien·ne·s</h2>
 
     {% for person in members %}
         {% capture end_date_as_string %}{{ person.end }}{% endcapture %}


### PR DESCRIPTION
Chrome 69 n'effectue plus le rendu des composants Semantic UI de la même façon que les versions précédentes. Cette PR "corrige" le défaut en ajoutant une classe `container` aux `divider`s horizontaux dans la page communauté, c'est tout à fait empirique.

Fixes #1749 (workaround)