### PR TITLE
Corrige les balises de titre dans les offres de recrutement

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,8 +3,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}</title>
-    <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
+    <title>{% if page.title %}{{ layout.title | default: page.title }} — {% endif %}{{ site.title }}</title>
+    <meta property="og:title" content="{{ layout.title | default: page.title | default: site.title }}">
 
     <link type="application/atom+xml" rel="alternate" href="{{ site.url }}/feed.xml" title="{{ site.title }}">
 

--- a/_layouts/job.html
+++ b/_layouts/job.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Les Startups d’État recrutent
 ---
 
 {% assign job = page %}
@@ -14,7 +15,8 @@ layout: default
 
 <div class="post-container">
     <article class="post">
-        <h1>{% if startup %}{{ startup.title }}{% elsif job.type == 'friend' %}{{ job.friend }}{% else %}beta.gouv.fr{% endif %} recrute {{ job.roles | downcase }}</h1>
+        {% capture pagetitle %}{% if startup %}{{ startup.title }}{% elsif job.type == 'friend' %}{{ job.friend }}{% else %}beta.gouv.fr{% endif %} recrute {{ job.roles | downcase }}{% endcapture %}
+        <h1>{{ pagetitle }}</h1>
 
         {% if job.type == 'friend' %}
             <div class="subtitle external-link">


### PR DESCRIPTION
On a encore voulu faire trop malin en générant des titres de façon sophistiquée à partir du champ `roles`, pour ne pas avoir à répéter le nom de la startup. Pour l'instant on corrige rapidement en donnant un titre générique aux pages de recrutement. Pour améliorer le référencement par exemple, il vaudrait mieux revenir à un champ `title` dans toutes les offres d'emploi qui reprendrait la même information que le champ `roles`.

Fixes #1755