### PR TITLE
Modification home - améliorations et fixes ie10/11

### DIFF
--- a/_pages/fr/index.html
+++ b/_pages/fr/index.html
@@ -23,11 +23,6 @@ title: Incubateur de services publics numériques
       <p>Des <strong>équipes pilotées par la finalité</strong> plus que par les moyens</p>
       <p><strong>Amélioration continue</strong> plus que conformité à un plan</p>
     </div>
-
-    <div class="row centered">
-      <a href="/startups" class="button large">Voir notre portefeuille</a>
-      <a href="/incubateurs" class="button large">En savoir plus</a>
-    </div>
   </div>
 </section>
 

--- a/_pages/fr/index.html
+++ b/_pages/fr/index.html
@@ -42,7 +42,7 @@ title: Incubateur de services publics numériques
                     </a>
                     <a class="link" href="https://startupdetat.typeform.com/to/ASluPI">
                         <img src="../img/icons/book.svg" alt="Icône livre" />
-                        <p>Inscrivez-vous à notre formation gratuite Alpha</p>
+                        <p>Inscrivez-vous à<br>notre formation gratuite Alpha</p>
                     </a>
                 </div>
             </div>

--- a/_pages/fr/index.html
+++ b/_pages/fr/index.html
@@ -27,7 +27,7 @@ title: Incubateur de services publics numériques
 </section>
 
 <section class="section-grey mosaic">
-    <div class="container">
+    <div class="container" style="max-width: none;">
         <div class="row public-agents inverted">
             <div class="photo agents"></div>
             <div class="stacked">


### PR DESCRIPTION
- Suppression des CTA sur la home
- Ajout d'un saut de ligne sur l'incitation à découvrir la formation Alpha

Sous IE10 et IE11, l'alignement est à la ramasse

![alignement-ramasse](https://user-images.githubusercontent.com/25476945/45891899-fbc58400-bdc6-11e8-8057-2bd32841fd0f.png)

**Quickfix rapide et dirty :  mettre `<div class="container" style="max-width: none;">`**

![alignement-ramasse-2](https://user-images.githubusercontent.com/25476945/45891918-03852880-bdc7-11e8-95cb-7f710ca1b671.png)

Cela ne semble pas impacter le display sur les autres navigateurs, mais en cas d'agrandissement, des marges apparaissent.

Si vous avez une autre façon d'implémenter qui soit moins barbare...
