### PR TITLE
fix inactive members of startups

### DIFF
--- a/_includes/startup-card.html
+++ b/_includes/startup-card.html
@@ -78,7 +78,7 @@
                                 {% assign isInactive = true %}
                         {% endif %}
                     {% endif %}
-                    <div class="ui tiny label {% if isInactive %}inactive{% endif %}">{{author.fullname}}</div>
+                    <div class="label {% if isInactive %}label--inactive{% endif %}">{{author.fullname}}</div>
                 {% endif %}
             {% endfor %}
         {% endfor %}


### PR DESCRIPTION
Restore inactive state of startup members labels.

Fix #1798 

![image](https://user-images.githubusercontent.com/1301085/46014008-316fb300-c0ce-11e8-94a4-c3475fa8af57.png)
