### PR TITLE
Affichage des auteurs

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -15,16 +15,10 @@
 
 <div class="article__author panel{% if include.isInactive %} inactive{% endif %}">
 
-    {% if description.link %}
-        <a class="content" href="{{ description.link }}" target="_blank" rel="noopener">
-    {% else %}
-        <div class="content">
-    {% endif %}
-
-    <div class="article__author-info">
-        <div class="article__author-name">{{ description.fullname }}</div>
-        <div class="article__author-role">{{ description.role }}</div>
-    </div>
+  <div class="article__author-info">
+      <div class="article__author-name">{{ description.fullname }}</div>
+      <div class="article__author-role">{{ description.role }}</div>
+  </div>
 
     {% if include.size != 'small' %}
         {{ avatar }}
@@ -35,14 +29,10 @@
     {% endif %}
 
     <div class="article__author-description">
+      {% if description.link %}<a href="{{ description.link }}" target="_blank" rel="noopener">{% endif %}
         {{ description.content | markdownify }}
+      {% if description.link %}</a>{% endif %}
     </div>
-
-    {% if description.link %}
-        </a>
-    {% else %}
-        </div>
-    {% endif %}
 
     {% if description.startups and include.size != 'small' %}
         <div class="card__extra">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -35,20 +35,21 @@ layout: default
           </div>
         {% endif %}
 
-        {% if page.authors %}
-        <address class="ui stackable cards">
-          {% for author in page.authors %}
-          {% include author.html id=author size='small' %}
-          {% endfor %}
-        </address>
-        {% endif %}
-
-        <footer>
-          <h3>Un avis, une question ?</h3>
-          <p>Écrivez-nous <a href="https://twitter.com/intent/tweet?text=%40BetaGouv%20Au%20sujet%20de%20{{ page.title | uri_escape }}%20%3a%20">@BetaGouv sur Twitter</a> ou envoyez-nous <a href="mailto:social@beta.gouv.fr?subject={{ page.title | uri_escape }}">un mail</a>.</p>
-          <p>Vous avez repéré une coquille ? <a href="https://github.com/betagouv/beta.gouv.fr/edit/master/{{ page.path }}">Corrigez-la</a> !</p>
-        </footer>
       </div>
+
+      {% if page.authors %}
+      <div class="article__author-list">
+        {% for author in page.authors %}
+        {% include author.html id=author size='small' %}
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      <footer>
+        <h3>Un avis, une question ?</h3>
+        <p>Écrivez-nous <a href="https://twitter.com/intent/tweet?text=%40BetaGouv%20Au%20sujet%20de%20{{ page.title | uri_escape }}%20%3a%20">@BetaGouv sur Twitter</a> ou envoyez-nous <a href="mailto:social@beta.gouv.fr?subject={{ page.title | uri_escape }}">un mail</a>.</p>
+        <p>Vous avez repéré une coquille ? <a href="https://github.com/betagouv/beta.gouv.fr/edit/master/{{ page.path }}">Corrigez-la</a> !</p>
+      </footer>
     </div>
   </div>
 </section>


### PR DESCRIPTION
En lien avec https://github.com/betagouv/beta.gouv.fr/issues/1796 .

L'affichage des auteurs d'un article est mal formaté suite au passage sur le nouveau template.

Ce premier correctif permet de repartir sur le template https://template.data.gouv.fr/ avec les sections / divs associés afin de mettre à jour directement les CSS (problèmes lorsque les descriptions ne sont pas remplies), à voir ensuite avec @thimy .