### PR TITLE
adjust photos to make them square

### DIFF
--- a/css/communaute.css
+++ b/css/communaute.css
@@ -20,7 +20,7 @@
 }
 
 .card .card__cover {
-  height: 310px;
+  height: 210px;
 }
 
 a.card__content {


### PR DESCRIPTION
Resized community members pictures to be square when page is full sized.

![image](https://user-images.githubusercontent.com/1301085/46039112-343dc880-c10d-11e8-9afc-2f3a13f06ce9.png)
