### PR TITLE
Changement lien blog

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,7 +46,7 @@
                             </a>
                         </li>
                         <li class="nav__item">
-                            <a class="{% if page.url == '/blog/' %}active{%endif%}" href="https://lactu.beta.gouv.fr">
+                            <a class="{% if page.url == '/blog/' %}active{%endif%}" href="https://blog.beta.gouv.fr">
                                 Blog
                             </a>
                         </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,7 +46,7 @@
                             </a>
                         </li>
                         <li class="nav__item">
-                            <a class="{% if page.url == '/blog/' %}active{%endif%}" href="/blog/">
+                            <a class="{% if page.url == '/blog/' %}active{%endif%}" href="https://lactu.beta.gouv.fr">
                                 Blog
                             </a>
                         </li>


### PR DESCRIPTION
Suite à mes travaux estivaux et à un coup d'accélérateur à la rentrée, je fais cette PR pour remplacer le lien du blog du site vers lactu.beta.gouv.fr

> Intégration des stats OK
> Gestion des catégories
> Gestion des auteurs
> Moteur de recherche
> Articles relatifs
> et surtout : CMS Netlify pour créer / éditer / mettre à jour les articles

Dans un premier temps afin de ne pas perdre le référencement, les articles déjà écrit sur beta.gouv.fr restent pour conserver les liens. Une redirection plus générique de /blog pourrait être mise en place mais ce n'est pas bloquant : les articles ont déjà migrés.