### PR TITLE
Supprime la notion d'ami de l'offre data.gouv.fr

### DIFF
--- a/_jobs/2018-10-01-dev-datagouv.md
+++ b/_jobs/2018-10-01-dev-datagouv.md
@@ -1,8 +1,8 @@
 ---
 friend: 'data.gouv.fr'
+startup: data.gouv.fr
 roles: un·e développeur·se
-techno: Flask / Vue.JS 
-type: 'friend'
+techno: Flask / Vue.JS
 open: true
 ---
 


### PR DESCRIPTION
Cette PR propose de supprimer la partie "Nos ami·e·s recrutent" pour l'offre data.gouv.fr.
data.gouv.fr est sur la page https://beta.gouv.fr/startups/, l'équipe est connue et respecte le manifeste.
