### PR TITLE
Change 2 startups' owner for consistency

### DIFF
--- a/_startup/civils-de-la-defense.md
+++ b/_startup/civils-de-la-defense.md
@@ -1,7 +1,7 @@
 ---
 title: Civils de la Défense
 mission: Recruter simplement des agents civils sous contrat
-owner: le ministère des Armées
+owner: Ministère des Armées
 incubator: dinsic
 status: construction
 start: 2018-06-01

--- a/_startup/e-chauffeur.md
+++ b/_startup/e-chauffeur.md
@@ -1,7 +1,7 @@
 ---
 title: e-Chauffeur
 mission: Optimiser le service de voiture de transport avec chauffeur au sein des bases de défense
-owner: le ministère des Armées
+owner: Ministère des Armées
 incubator: dinsic
 status: construction
 start: 2018-09-01


### PR DESCRIPTION
J'avais ajouté un article devant le nom du ministère pour plus de lisibilité sur les fiches produit 
<img width="553" alt="capture_d___e__cran_2018-10-11_a___12 17 52" src="https://user-images.githubusercontent.com/5756228/46798576-a4c22780-cd52-11e8-83d2-e54d06855d49.png">

Mais du coup on se retrouvait avec un truc étrange sur la page `startups`
![image](https://user-images.githubusercontent.com/5756228/46798617-c15e5f80-cd52-11e8-94ae-14900fe321ea.png)

Du coup je reviens en arrière pour être consistant avec les autres startups.
