### PR TITLE
Add jerome.rivals.md

### DIFF
--- a/_authors/jerome.rivals.md
+++ b/_authors/jerome.rivals.md
@@ -1,0 +1,12 @@
+---
+fullname: Jérôme Rivals
+role: Développeur
+avatar: https://avatars3.githubusercontent.com/jrivals?s=600
+github: jrivals
+start: 2018-11-08
+end: 2019-04-01
+employer: independent/octo
+startups:
+    - signalement
+---
+


### PR DESCRIPTION
Ajout dans la communauté d'un nouveau membre (Jérôme Rivals) qui rejoint la startup Signalement à compter du 08/11/18 en tant que développeur.
