### PR TITLE
Corriger l'affichage des auteurs

### DIFF
--- a/_includes/avatar.html
+++ b/_includes/avatar.html
@@ -3,9 +3,9 @@
   Ex : {% include avatar.html author=author %}
 {% endcomment %}
 
-{% assign id = include.author.id | remove: '/authors/' %}
+{% assign author_id = include.author.id | remove: '/authors/' %}
 {% assign screenshot_files = site.static_files | where: "authors_img", true %}
-{% assign screenshot_file = screenshot_files | where: 'basename', id | first %}
+{% assign screenshot_file = screenshot_files | where: 'basename', author_id | first %}
 {% if screenshot_file %}
   {% assign screenshot_path = screenshot_file.path %}
   <img class="screenshot" src="{{ screenshot_path }}" title="{{ include.author.fullname }}" alt="">
@@ -13,5 +13,5 @@
   <img class="screenshot" src="{{ include.author.avatar }}" title="{{ include.author.fullname }}" alt="">
 {% elsif include.force %}
   {% assign screenshot_path = "/img/logo-generique-startup-carre.jpg" %}
-  <img class="screenshot" src="{{ screenshot_path }}" title="{{ include.startup.title }} est encore en travaux" alt="">
+  <img class="screenshot" src="{{ screenshot_path }}" title="{{ include.author.fullname }}" alt="">
 {% endif %}

--- a/_includes/card-community.html
+++ b/_includes/card-community.html
@@ -5,6 +5,20 @@
 
 {% assign author= include.author %}
 
+{% comment %}
+  Détecter si l'author est actif ou non. Par défaut, oui.
+{% endcomment %}
+
+{% capture label %}label--active{% endcapture %}
+
+{% if author.end %}
+  {% capture timestampNow %}{{ 'now' | date: '%s' }}{% endcapture %}
+  {% capture timestampEnd %}{{ author.end | date: '%s' }}{% endcapture %}
+  {% if timestampNow > timestampEnd %}
+    {% capture label %}label--inactive{% endcapture %}
+  {% endif %}
+{% endif %}
+
 <div class="card">
   {% if author.link %}<a href="{{ author.link }}" target="\_blank" rel="noopener">{% endif %}
     <div class="card__cover">
@@ -22,7 +36,7 @@
     {% for startup in author.startups %}
       {% capture startup_id %}/startups/{{ startup }}{% endcapture %}
       {% assign this_startup = site.startups | where: "id", startup_id | first %}
-      <div class="label label--active"><a href="{{ this_startup.url }}">{{ this_startup.title }}</a></div>
+      <div class="label {{ label }}"><a href="{{ this_startup.url }}">{{ this_startup.title }}</a></div>
     {% endfor %}
     {% for startup in author.previously %}
       {% capture startup_id %}/startups/{{ startup }}{% endcapture %}

--- a/_includes/card-startup.html
+++ b/_includes/card-startup.html
@@ -3,7 +3,6 @@
   Ex : {% include card-startup.html startup = startup %}
 {% endcomment %}
 
-{% assign id = startup.id | remove: '/startups/' %}
 <div class="card">
   <a href="{{ startup.url }}">
     <div class="card__cover">
@@ -35,42 +34,42 @@
     </p>
   </div>
   <div class="card__extra">
-    {% assign id = startup.id | remove: "/startups/" %}
+    {% comment %}<!-- Initialiser les équipes : les actuels, ceux qui sont parti, et ceux qui se sont retirés -->{% endcomment %}
     {% assign current_team = "" %}{% comment %}membres actuels, actifs{% endcomment %}
-    {% assign inactive_team = "" %}{% comment %}membres actuels, inactifs{% endcomment %}
+    {% assign current_inactive_team = "" %}{% comment %}membres actuels, inactifs{% endcomment %}
     {% assign past_team = "" %}{% comment %}anciens membres, toujours actifs{% endcomment %}
-    {% assign inactive_past_team = "" %}{% comment %}anciens membres, inactifs{% endcomment %}
-    {% assign team = site.authors | where:"startups", id %}
+
+    {% comment %}<!-- Initialiser l'id -->{% endcomment %}
+    {% assign startup_id = startup.id | remove: "/startups/" %}
+
+    {% comment %}<!-- On boucle en premier sur tous ceux qui se sont déclarés actifs sur la startup -->{% endcomment %}
+    {% assign team = site.authors | where:"startups", startup_id %}
     {% for people in team %}
+      {% comment %}<!-- On détecte ceux qui ne sont plus actifs sur la communauté -->{% endcomment %}
       {% if people.end %}
         {% capture timestampNow %}{{ 'now' | date: '%s' }}{% endcapture %}
         {% capture timestampEnd %}{{ people.end | date: '%s' }}{% endcapture %}
         {% if timestampNow > timestampEnd %}
           {% capture to_append %}<div class="label label--inactive">{{ people.fullname }}</div>{% endcapture %}
-          {% assign inactive_team = inactive_team | append: to_append %}
+          {% assign current_inactive_team = current_inactive_team | append: to_append %}
           {% continue %}
         {% endif %}
       {% endif %}
+      {% comment %}<!-- On passe aux actifs de la communauté et de la startup -->{% endcomment %}
       {% capture to_append %}<div class="label label--active">{{ people.fullname }}</div>{% endcapture %}
       {% assign current_team = current_team | append: to_append %}
     {% endfor %}
-    {% assign team = site.authors | where:"previously", id %}
+
+    {% comment %}<!-- Maintenant, on passe à tous ceux qui se sont déclarés inactifs spontanément -->{% endcomment %}
+    {% assign team = site.authors | where:"previously", startup_id %}
     {% for people in team %}
-      {% if people.end %}
-        {% capture timestampNow %}{{ 'now' | date: '%s' }}{% endcapture %}
-        {% capture timestampEnd %}{{ people.end | date: '%s' }}{% endcapture %}
-        {% if timestampNow > timestampEnd %}
-          {% capture to_append %}<div class="label label--inactive">{{ people.fullname }}</div>{% endcapture %}
-          {% assign inactive_past_team = inactive_past_team | append: to_append %}
-          {% continue %}
-        {% endif %}
-      {% endif %}
       {% capture to_append %}<div class="label label--inactive">{{ people.fullname }}</div>{% endcapture %}
       {% assign past_team = past_team | append: to_append %}
     {% endfor %}
+
+    {% comment %}<!-- Pour l'affichage, on met les actifs, ceux qui ne sont plus dans la commaunté, puis ceux déclarés inactifs -->{% endcomment %}
     {{ current_team }}
+    {{ current_inactive_team }}
     {{ past_team }}
-    {{ inactive_team }}
-    {{ inactive_past_team }}
   </div>
 </div>

--- a/_includes/grid-authors.html
+++ b/_includes/grid-authors.html
@@ -1,17 +1,20 @@
 {% comment %}
-  Appeler cette page avec en paramètre l'ID d'une startup
-  ex : {% include grid-authors.html id=id %}
+  Appeler cette page avec une startup
+  ex : {% include grid-authors.html startup=startup %}
 {% endcomment %}
 
-{% assign current_team = "" %}{% comment %}membres actuels, actifs{% endcomment %}
-{% assign inactive_team = "" %}{% comment %}membres actuels, inactifs{% endcomment %}
+{% comment %}<!-- Initialiser les équipes : les actuels, ceux qui sont parti, et ceux qui se sont retirés -->{% endcomment %}
+{% assign current_team = "" %}{% comment %}membres actuels, actifs dans la startup{% endcomment %}
+{% assign current_inactive_team = "" %}{% comment %}membres actuels, inactifs{% endcomment %}
 {% assign past_team = "" %}{% comment %}anciens membres, toujours actifs{% endcomment %}
-{% assign inactive_past_team = "" %}{% comment %}anciens membres, inactifs{% endcomment %}
 
-{% assign id = include.id %}
+{% comment %}<!-- Initialiser l'id -->{% endcomment %}
+{% assign startup_id = include.startup.id | remove: '/startups/' %}
 
-{% assign team = site.authors | where:"startups", id %}
+{% comment %}<!-- On boucle en premier sur tous ceux qui se sont déclarés actifs sur la startup -->{% endcomment %}
+{% assign team = site.authors | where:"startups", startup_id %}
 {% for people in team %}
+  {% comment %}<!-- On détecte ceux qui ne sont plus actifs sur la communauté -->{% endcomment %}
   {% if people.end %}
     {% capture timestampNow %}{{ 'now' | date: '%s' }}{% endcapture %}
     {% capture timestampEnd %}{{ people.end | date: '%s' }}{% endcapture %}
@@ -30,10 +33,11 @@
           </div>
       </div>
       {% endcapture %}
-      {% assign inactive_team = inactive_team | append: to_append %}
+      {% assign current_inactive_team = current_inactive_team | append: to_append %}
       {% continue %}
     {% endif %}
   {% endif %}
+  {% comment %}<!-- On passe aux actifs de la communauté et de la startup -->{% endcomment %}
   {% capture to_append %}
   <div class="article__author panel">
     <div class="article__author-info">
@@ -51,30 +55,9 @@
   {% assign current_team = current_team | append: to_append %}
 {% endfor %}
 
-{% assign team = site.authors | where:"previously", id %}
+{% comment %}<!-- Maintenant, on passe à tous ceux qui se sont déclarés inactifs spontanément -->{% endcomment %}
+{% assign team = site.authors | where:"previously", startup_id %}
 {% for people in team %}
-  {% if people.end %}
-    {% capture timestampNow %}{{ 'now' | date: '%s' }}{% endcapture %}
-    {% capture timestampEnd %}{{ people.end | date: '%s' }}{% endcapture %}
-    {% if timestampNow > timestampEnd %}
-      {% capture to_append %}
-      <div class="article__author panel inactive">
-        <div class="article__author-info">
-            <div class="article__author-name">{{ people.fullname }}</div>
-            <div class="article__author-role">{{ people.role }}</div>
-        </div>
-          {% include avatar.html author=people %}
-          <div class="article__author-description">
-            {% if people.link %}<a href="{{ people.link }}" target="_blank" rel="noopener">{% endif %}
-              {{ people.content | markdownify }}
-            {% if people.link %}</a>{% endif %}
-          </div>
-      </div>
-      {% endcapture %}
-      {% assign inactive_past_team = inactive_past_team | append: to_append %}
-      {% continue %}
-    {% endif %}
-  {% endif %}
   {% capture to_append %}
   <div class="article__author panel inactive">
     <div class="article__author-info">
@@ -89,12 +72,12 @@
       </div>
   </div>
   {% endcapture %}
-  {% assign inactive_team = inactive_team | append: to_append %}
+  {% assign past_team = past_team | append: to_append %}
 {% endfor %}
 
+{% comment %}<!-- Pour l'affichage, on met les actifs, ceux qui ne sont plus dans la commaunté, puis ceux déclarés inactifs -->{% endcomment %}
 <div class="grid">
   {{ current_team }}
+  {{ current_inactive_team }}
   {{ past_team }}
-  {{ inactive_team }}
-  {{ inactive_past_team }}
 </div>

--- a/_includes/screenshot.html
+++ b/_includes/screenshot.html
@@ -3,9 +3,9 @@
   Ex : {% include screenshot.html startup=startup %}
 {% endcomment %}
 
-{% assign id = include.startup.id | remove: '/startups/' %}
+{% assign startup_id = include.startup.id | remove: '/startups/' %}
 {% assign screenshot_files = site.static_files | where: "startups_img", true %}
-{% assign screenshot_file = screenshot_files | where: 'basename', id | first %}
+{% assign screenshot_file = screenshot_files | where: 'basename', startup_id | first %}
 {% if screenshot_file %}
   {% assign screenshot_path = screenshot_file.path %}
   <img class="screenshot" src="{{ screenshot_path }}" title="Interface de {{ include.startup.title }}" alt="">

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -83,8 +83,7 @@ layout: default
 
   <section class="section section-grey">
     <div class="container">
-      {% assign id = page.id | remove: '/startups/' %}
-      {% include grid-authors.html id=id %}
+      {% include grid-authors.html startup=page %}
     </div>
   </section>
 


### PR DESCRIPTION
- Correction d'un problème dans l'affichage des auteurs sur la page d'une startup : certains n'étaient plus affichés à cause d'une collision sur la variable `id`
- Optimisations en conséquence pour une meilleure lisibilité
- Documentation du code car ces pages sont complexes à appréhender



_Précisions pour la postérité et pour la personne qui se replongera dans l'historique de ces lignes de code_

Deux variables sont à prendre en compte pour afficher les membres d'une startup.

1) Sur la fiche authors, le membre est-il actif dans dans communauté ou non ?
2) Sur la fiche authors, la startup est-elle dans "startups" ou dans "previously" ?

Ce qui entraine mécaniquement 4 combinaisons possibles.

Dans une première version, je testais les 4. Avec cette PR, j'en teste 3, partant du principe que si la startup est en "previously", alors cela importe peu de savoir si le membre est toujours actif ou non.

Les autres modifications concernent les noms des variables afin d'éviter des collisions dans les includes : au lieu d'utiliser `id` à chaque fois, je l'ai qualifié en `startup_id` et `author_id`.