### PR TITLE
Une seule adresse de contact

### DIFF
--- a/content/_jobs/2018-11-26-mobilot-bizdev.md
+++ b/content/_jobs/2018-11-26-mobilot-bizdev.md
@@ -53,4 +53,4 @@ En dernière année d’une école d’ingénieur, de management ou de commerce 
 * Pour postuler, écrivez-nous à l’adresse recrutement@beta.gouv.fr avec votre LinkedIn / CV
 * L’entretien se fera à Cahors.
 
-Intéressé·e par la mission ? Ecrivez-nous à l'adresse contact@lotocar.fr
+Intéressé·e par la mission ? Ecrivez-nous vite.


### PR DESCRIPTION
Typo dans l'annonce sur l'adresse de contact