### PR TITLE
Atteindre l'API depuis un autre site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ plugins:
 
 lang: fr
 
-include: ["_pages", "_redirects"]
+include: ["_pages", "_redirects", "_headers"]
 exclude: ["content/templates", "CONTRIBUTING.md", "rb", "vendor"]
 
 sass:

--- a/_headers
+++ b/_headers
@@ -1,0 +1,4 @@
+## Permettrea aux autres sites d'avoir accès à l'API via https://beta.gouv.fr/api/*
+## Documentation : https://www.netlify.com/docs/headers-and-basic-auth/
+/api/*
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
Permettre aux sites distants d'avoir accès à l'API.

Actuellement, la StandUp Machine est cassée avec ce message.

`Access to XMLHttpRequest at 'https://beta.gouv.fr/api/v1.6/startups.json' from origin 'https://stand-up.surge.sh' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.`

Cette PR ajoute `Access-Control-Allow-Origin: *` sur /api/* afin de réparer :)

En savoir plus : https://www.netlify.com/docs/headers-and-basic-auth/