### PR TITLE
Corrige le mail de contact de l'offre WorkInFrance

### DIFF
--- a/content/_jobs/2018-11-29-WorkInFrance-charge-deploiement.md
+++ b/content/_jobs/2018-11-29-WorkInFrance-charge-deploiement.md
@@ -44,6 +44,6 @@ Il s’agira donc de :
 - Démarrage en Janvier 2019
 
 ## Candidater
-Écrivez-nous à l'adresse [contact@workinfrance@beta.gouv.fr](mailto:contact@workinfrance@beta.gouv.fr) et venez partager vos expériences et vos belles histoires dans la construction de produits qui marchent 😉
+Écrivez-nous à l'adresse [contact@workinfrance.beta.gouv.fr](mailto:contact@workinfrance.beta.gouv.fr) et venez partager vos expériences et vos belles histoires dans la construction de produits qui marchent 😉
 
 


### PR DESCRIPTION
D'après https://workinfrance.beta.gouv.fr/, le mail de contact serait plutôt contact@workinfrance.beta.gouv.fr (avec un point à la place de la seconde @)