### PR TITLE
Mise à jour des statuts des Startups MTES MASS

### DIFF
--- a/content/_startups/a-dock.md
+++ b/content/_startups/a-dock.md
@@ -3,7 +3,7 @@ title: A Dock
 mission: Simplifier la relation transporteur-chargeur
 owner: Ministère de la Transition écologique et solidaire 
 incubator: mtes
-status: construction
+status: acceleration
 start: 2018-01-08
 end:
 link: https://adock.beta.gouv.fr

--- a/content/_startups/aides-territoires.md
+++ b/content/_startups/aides-territoires.md
@@ -3,7 +3,7 @@ title: Aides-territoires
 mission: Accéder aux meilleures aides pour les projets de votre territoire
 owner: Ministère de la Cohésion des territoires / Ministère de la Transition écologique et solidaire
 incubator: mtes
-status: construction
+status: acceleration
 start: 2018-01-01
 end: 2018-07-30
 link: http://www.aides-territoires.beta.gouv.fr/

--- a/content/_startups/camino.md
+++ b/content/_startups/camino.md
@@ -3,7 +3,7 @@ title: Camino
 mission: Ouvrir les données du domaine minier pour partager l'information sur les projets et faciliter leur gestion.
 owner: Ministère de la Transition écologique et solidaire
 incubator: mtes
-status: construction
+status: acceleration
 start: 2018-01-01
 end:
 link: https://camino.beta.gouv.fr

--- a/content/_startups/co-construisons.md
+++ b/content/_startups/co-construisons.md
@@ -3,7 +3,7 @@ title: Co-construisons
 mission: Mettre les petites contributions numériques au service de l'intérêt général
 owner: Ministère de la Cohésion des territoires / Ministère de la Transition écologique et solidaire
 incubator: mtes
-status: construction
+status: acceleration
 start: 2017-12-15
 end:
 link: http://site-1356466-3064-3975.strikingly.com/

--- a/content/_startups/codedutravail.md
+++ b/content/_startups/codedutravail.md
@@ -3,7 +3,7 @@ title: Code du travail numérique
 mission: Faciliter l'accès au droit du travail pour les employeur·e·s et les employé·e·s.
 owner: Ministère des Affaires sociales
 incubator: sgmas
-status: construction
+status: acceleration
 start: 2017-12-01
 end:
 link: https://codedutravail.num.social.gouv.fr

--- a/content/_startups/e-mjpm.md
+++ b/content/_startups/e-mjpm.md
@@ -3,7 +3,7 @@ title: e-MJPM
 mission: Trouver rapidement le bon professionnel pour les majeurs à protéger
 owner: Ministère des Affaires sociales
 incubator: sgmas
-status: construction
+status: acceleration
 start: 2017-10-26
 end:
 link: https://emjpm.num.social.gouv.fr/

--- a/content/_startups/workinfrance.md
+++ b/content/_startups/workinfrance.md
@@ -3,7 +3,7 @@ title: Work in France
 mission: La plateforme de demande d’autorisations provisoires de travail
 owner: Ministère des Affaires sociales
 incubator: sgmas
-status: construction
+status: acceleration
 start: 2017-10-26
 end:
 link: https://workinfrance.beta.gouv.fr


### PR DESCRIPTION
Afin de mettre à jour le site beta.gouv.fr, je propose de passer l'ensemble des Startups d'Etat qui ont été refinancées pour une saison 2 au MASS et au MTES du statut "construction" au statut "accélération"

Cela impacte les Startups suivantes : 
- A Dock
- Aides-territoires
- Camino
- Co-construisons
- Code du travail numérique
- eMJPM
- WorkinFrance