### PR TITLE
utilise dosseirsco.fr comme url du projet maintenant

### DIFF
--- a/content/_startups/dossiersco.md
+++ b/content/_startups/dossiersco.md
@@ -6,7 +6,7 @@ incubator: dinsic
 status: construction
 start: 2017-09-01
 end:
-link: https://dossiersco.beta.gouv.fr
+link: https://dossiersco.fr
 repository: https://github.com/betagouv/dossiersco
 stats: true
 contact: pierre.de-maulmont@ac-paris.fr


### PR DESCRIPTION
Suite à la récupération du nom de domaine dossiersco.fr , nous (re-)passons le projet derrière cette url.

