### PR TITLE
Paramétrage compteur Smiirl

### DIFF
--- a/compteur_smiirl.json
+++ b/compteur_smiirl.json
@@ -1,0 +1,11 @@
+---
+---
+[
+    {
+
+      "authors"    : "{{ site.authors | size }}",
+      "incubateurs"   : "{{ site.incubators | size }}",
+      "startups" : "{{ site.startups | size }}"
+
+    }
+]


### PR DESCRIPTION
Ajout de trois options pour le compteur Smiirl qui prend la poussière :

- nombre de startups
- nombre d'incubateurs
- nombre de membres