### PR TITLE
FixFix! Smiirl compteur

### DIFF
--- a/compteur_smiirl.json
+++ b/compteur_smiirl.json
@@ -2,10 +2,5 @@
 ---
 
     {
-
-      "authors"    : "{{ site.authors | size }}",
-      "incubateurs"   : "{{ site.incubators | size }}",
-      "startups" : "{{ site.startups | size }}"
-
+      "number" : {{ site.startups | size }}
     }
-


### PR DESCRIPTION
OK, cette fois c'est la bonne.

En gros, on peut avoir un .json comme compteur. Mais avec un formatage très très précis parce que leur parseur, c'est pas ça.