### PR TITLE
Expérimentation inclusive newsletter

### DIFF
--- a/_includes/card-job.html
+++ b/_includes/card-job.html
@@ -27,9 +27,13 @@
   </div>
   {% if job.techno or job.junior or job.type == 'friend' %}
     <div class="card__extra">
-      {% if job.type == 'friend' %}<div class="label label--active">Nos ami·e·s recrutent</div>{% endif %}
-      {% if job.junior %}<div class="label label--active">Juniors bienvenu·e·s</div>{% endif %}
-      {% if job.techno %}<div class="label label--inactive">{{ job.techno }}</div>{% endif %}
+      {% if job.type == 'friend' %}<div class="label label--active">Nos amis recrutent</div>{% endif %}
+      {% if job.junior %}<div class="label label--active">Bienvenue aux juniors !</div>{% endif %}
+      {% if job.techno %}
+        {% for techno in job.techno %}
+        <div class="label label--inactive">{{ techno }}</div>
+        {% endfor %}
+      {% endif %}
     </div>
   {% endif %}
 </div>

--- a/_layouts/job.html
+++ b/_layouts/job.html
@@ -10,7 +10,7 @@ layout: default
   {% include hero-job.html startup=startup roles=page.roles friend=page.friend %}
 
   {% if page.type == 'friend' %}
-    <div class="notification full-width">Une offre à pourvoir chez nos ami·e·s <br /><a href="{{ page.externalURL}}">Voir l'offre sur le site de {{ page.friend }}</a></div>
+    <div class="notification full-width">Une offre à pourvoir chez nos amis <br /><a href="{{ page.externalURL}}">Voir l'offre sur le site de {{ page.friend }}</a></div>
   {% endif %}
 
   {% if page.open %}
@@ -24,8 +24,18 @@ layout: default
       <div class="container">
         <div class="text-quote">
           <ul>
-            {% if page.junior %}<li>Les juniors sont bienvenu·e·s sur ce poste ! L'équipe assurera votre formation.</li>{% endif %}
-            {% if page.techno %}<li>Technologie·s retenue·s : {{ page.techno }}.</li>{% endif %}
+            {% if page.junior %}
+              <li>Bienvenue aux juniors sur ce poste ! L'équipe assurera votre formation.</li>
+            {% endif %}
+            {% if page.techno %}
+              <li>Technologies retenues :
+                <ul>
+                  {% for techno in page.techno %}
+                  <li>{{ techno }}</li>
+                  {% endfor %}
+                </ul>
+              </li>
+            {% endif %}
           </ul>
         </div>
       </div>

--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -16,15 +16,33 @@ layout: default
       </div>
     </div>
   </section>
-  <section class="section section-grey cards">
-    <div class="container jobs">
-      <h3>Offres pourvues</h3>
-      <div class="grid">
+  <section class="section section-grey">
+    <div class="container">
+      <a class="button" href="#previoux_jobs" onclick="toggle_visibility('previous_jobs');">Offres pourvues</a>
+      <div id="previous_jobs" style="display:none">
         {% assign jobs = site.jobs | where: "open", 'false' | reverse %}
+        <p>
+          <ul>
         {% for job in jobs %}
-          {% include card-job.html job=job %}
+          {% capture startup_id %}/startups/{{ job.startup }}{% endcapture %}
+          {% assign startup = site.startups | where: "id", startup_id | first %}
+          <li><a href="{{ job.url }}">{% if job.friend %}{{ job.friend }}{% else %}{{ startup.title | default: "beta.gouv.fr"}}{% endif %} : {{ job.roles }}, le <time datetime="{{ job.date | date:'%Y-%m-%d' }}">{{ job.date | date: "%d/%m/%Y" }}</time></a></li>
         {% endfor %}
+          </ul>
+        </p>
       </div>
     </div>
   </section>
 </div>
+
+<script type="text/javascript">
+<!--
+    function toggle_visibility(id) {
+       var e = document.getElementById(id);
+       if(e.style.display == 'block')
+          e.style.display = 'none';
+       else
+          e.style.display = 'block';
+    }
+//-->
+</script>

--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -18,7 +18,7 @@ layout: default
   </section>
   <section class="section section-grey">
     <div class="container">
-      <a class="button" href="#previoux_jobs" onclick="toggle_visibility('previous_jobs');">Offres pourvues</a>
+      <a class="button" href="#previous_jobs" onclick="toggle_visibility('previous_jobs');">Offres pourvues</a>
       <div id="previous_jobs" style="display:none">
         {% assign jobs = site.jobs | where: "open", 'false' | reverse %}
         <p>

--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -21,15 +21,13 @@ layout: default
       <a class="button" href="#previous_jobs" onclick="toggle_visibility('previous_jobs');">Offres pourvues</a>
       <div id="previous_jobs" style="display:none">
         {% assign jobs = site.jobs | where: "open", 'false' | reverse %}
-        <p>
-          <ul>
-        {% for job in jobs %}
-          {% capture startup_id %}/startups/{{ job.startup }}{% endcapture %}
-          {% assign startup = site.startups | where: "id", startup_id | first %}
-          <li><a href="{{ job.url }}">{% if job.friend %}{{ job.friend }}{% else %}{{ startup.title | default: "beta.gouv.fr"}}{% endif %} : {{ job.roles }}, le <time datetime="{{ job.date | date:'%Y-%m-%d' }}">{{ job.date | date: "%d/%m/%Y" }}</time></a></li>
-        {% endfor %}
-          </ul>
-        </p>
+        <ul>
+      {% for job in jobs %}
+        {% capture startup_id %}/startups/{{ job.startup }}{% endcapture %}
+        {% assign startup = site.startups | where: "id", startup_id | first %}
+        <li><a href="{{ job.url }}">{% if job.friend %}{{ job.friend }}{% else %}{{ startup.title | default: "beta.gouv.fr"}}{% endif %} : {{ job.roles }}, le <time datetime="{{ job.date | date:'%Y-%m-%d' }}">{{ job.date | date: "%d/%m/%Y" }}</time></a></li>
+      {% endfor %}
+        </ul>
       </div>
     </div>
   </section>

--- a/content/_jobs/2018-09-27-developpeurJS-PIX.md
+++ b/content/_jobs/2018-09-27-developpeurJS-PIX.md
@@ -1,7 +1,9 @@
 ---
 friend: 'PIX'
-roles: un.e développeur.e fullstack JS
-techno: Ember.JS / Node.JS 
+roles: un développeur ou une développeuse full stack JS
+techno:
+  - Ember.JS
+  - Node.JS
 type: 'friend'
 externalURL: 'https://pix.fr/recrutement/developpeur-web'
 open: true
@@ -51,4 +53,4 @@ La stack technique globale comprend :
 
 ## Postuler
 
-Si un bon CV est toujours agréable à lire, nous pensons qu’une bonne histoire bien racontée (avec son lot de projets et d’expériences, réussites ou échecs) est encore plus intéressante à découvrir. Décrivez-nous qui vous êtes et ce que vous pensez apporter à l’équipe par mail : recrutement@pix.fr
+Si un bon CV est toujours agréable à lire, nous pensons qu’une bonne histoire bien racontée (avec son lot de projets et d’expériences, réussites ou échecs) est encore plus intéressante à découvrir. Décrivez-nous qui vous êtes et ce que vous pensez apporter à l’équipe par mail : [recrutement@pix.fr](mailto:recrutement@pix.fr).

--- a/content/_jobs/2018-11-07-franceconnect-ops.md
+++ b/content/_jobs/2018-11-07-franceconnect-ops.md
@@ -1,5 +1,5 @@
 ---
-roles: un·e responsable d'exploitation
+roles: un ou une responsable d'exploitation
 friend: FranceConnect
 type: 'friend'
 open: true

--- a/content/_jobs/2019-01-29-developpeu-r-se-mrs.md
+++ b/content/_jobs/2019-01-29-developpeu-r-se-mrs.md
@@ -1,24 +1,28 @@
 ---
-roles: un·e dev web full stack
+roles: un développeur ou une développeuse web full stack
 open: true
-techno:  Python / Django / PostgreSQL
+techno:
+  - Python
+  - Django
+  - PostgreSQL
 startup: mrs
 ---
 
-MRS cherche un·e développeur·se pour un CDD ou un·e prestataire indépendant·e. Si vous avez déjà rempli le cerfa s3140 et pensez qu’on peut proposer une meilleure approche, venez nous rejoindre !
+MRS cherche un développeur ou une développeuse pour un CDD, ou un ou une prestataire, ou un indépendant ou une indépendante. Si vous avez déjà rempli le Cerfa s3140 et pensez qu’on peut proposer une meilleure approche, venez nous rejoindre !
 
 <!--more-->
 
 ## Ma santé, Mon transport
-L’équipe [MRS](https://www.mrs.beta.gouv.fr) cherche un·e développeur·se web full-stack senior pour une mission de 10 mois en renfort de l’équipe technique actuelle. L’Assurance Maladie lance sa 1ère startup d’État. Deux intrapreneurs se lancent dans un service de simplification des remboursements des transports en véhicules personnels, dans la mesure où votre médecin vous a fait une prescription médicale. Venez rejoindre une équipe motivée à proposer un service simple, pratique, confortable pour les usagers et un intérêt pour la société dans son ensemble. Vous serez en charge d’améliorer le produit pour les utilisateurs (assurés et collaborateurs CNAM) et d’assurer le bon fonctionnement du service.
+L’équipe [MRS](https://www.mrs.beta.gouv.fr) cherche un développeur ou une développeuse web full-stack senior pour une mission de 10 mois en renfort de l’équipe technique actuelle. L’Assurance Maladie lance sa 1re Startup d’État. Deux intrapreneurs se lancent dans un service de simplification des remboursements des transports en véhicules personnels, dans la mesure où votre médecin vous a fait une prescription médicale. Venez rejoindre une équipe motivée à proposer un service simple, pratique, confortable pour les usagers et un intérêt pour la société dans son ensemble. Vous serez en charge d’améliorer le produit pour les utilisateurs (assurés et collaborateurs CNAM) et d’assurer le bon fonctionnement du service.
 
 ## Compétences et expérience
 - Vous maitrisez la stack Python/Django/Javascript/PostgreSQL et êtes à l’aise avec son écosystème.
 - Vous avez déjà participé et contribué à des outils open source.
 - Vous avez à cœur de rendre un service de qualité et avez toujours en tête l’utilisateur final lorsque vous travaillez.
 - Vous connaissez et avez déjà utilisé des outils de gestion d’erreur/supervision/ops (Sentry, Netdata, Docker, etc…).
-Modalités
-- Poste ouvert pour un·e indépendant·e (en portage)
+
+## Modalités
+- Poste ouvert pour un indépendant ou une indépendante (en portage)
 - Temps partiel accepté
 - Télétravail partiel bienvenu, avec 1 jour/semaine à Toulouse pour retrouver toute l’équipe.
 

--- a/content/_jobs/2019-01-29-recrutement-perspectives-full-stack.md
+++ b/content/_jobs/2019-01-29-recrutement-perspectives-full-stack.md
@@ -1,5 +1,5 @@
 ---
-roles: un·e dev web full stack
+roles: un développeur ou une développeuse web full stack
 open: true
 startup: perspectives
 ---
@@ -10,9 +10,9 @@ Accélérez le retour à l'emploi !
 
 ## Contexte
 
-[Perspectives](https://beta.gouv.fr/startups/perspectives.html) est une start-up Pole Emploi créée en mai 2018 dont le but est d’accélérer le retour à l’emploi des candidats validés par la Méthode de Recrutement par Simulation (MRS). La MRS évalue les aptitudes des demandeurs d’emploi qui souhaitent exercer un nouveau métier encore jamais pratiqué. 
+[Perspectives](https://beta.gouv.fr/startups/perspectives.html) est une start-up Pole Emploi créée en mai 2018 dont le but est d’accélérer le retour à l’emploi des candidats validés par la Méthode de Recrutement par Simulation (MRS). La MRS évalue les aptitudes des demandeurs d’emploi qui souhaitent exercer un nouveau métier encore jamais pratiqué.
 
-Ce service est développé par Pôle emploi dans le cadre d’une Startup d’Etat. La startup est conçue et développée par une petite équipe agile et autonome, à l’écoute de ses utilisateurs et dotée d’une forte autonomie. 
+Ce service est développé par Pôle emploi dans le cadre d’une Startup d’État. La startup est conçue et développée par une petite équipe agile et autonome, à l’écoute de ses utilisateurs et dotée d’une forte autonomie.
 
 Rejoindre l’équipe de [Perspectives](https://beta.gouv.fr/startups/perspectives.html), c’est participer à l’aventure de la nouvelle administration au service de ses usagers.
 
@@ -40,8 +40,8 @@ En binôme du développeur en place depuis le début du projet, vous développer
 - Vous maîtrisez le développement Web, ses concepts et ses standards
 - Vous disposez d’une expérience concrète sur un projet en Scala
 - Vous êtes habitué à gérer du code source via GIT
-- Vous avez une capacité d’écoute, d’analyse 
-- Vous êtes autonome et force de proposition 
+- Vous avez une capacité d’écoute, d’analyse
+- Vous êtes autonome et force de proposition
 - Vous aimez travailler en équipe et coder en binôme
 - Vous ne maîtrisez pas tout ça, mais vous avez envie d’apprendre
 

--- a/content/_jobs/2019-02-11-dev-e-controle.md
+++ b/content/_jobs/2019-02-11-dev-e-controle.md
@@ -1,23 +1,26 @@
 ---
-roles: un·e développeur·e full stack
+roles: un développeur ou une développeuse full stack
 startup: e-controle
-techno: Javascript ES5/ES6, VueJS ou React,Python/Django
+techno:
+  - Javascript ES5/ES6
+  - VueJS ou React
+  - Python/Django
 open: true
 ---
 
-L’équipe e-contrôle cherche un·e developpeur full-stack pour l’aider à développer son outil permettant de soulager les agents de la Cour des comptes et des organismes contrôlés dans leurs échanges de documents.
+L’équipe e-contrôle cherche un développeur ou une développeuse full stack pour l’aider à développer son outil permettant de soulager les agents de la Cour des comptes et des organismes contrôlés dans leurs échanges de documents.
 
 <!--more-->
 
 ## e-contrôle
 
-Tu es développeur·se, et tu veux mettre tes compétences au profit de l’amélioration du service public ? Tu es à ton aise dans les contextes de petites équipes autonomes, agiles, et proches de leurs utilisateurs ? En rejoignant une Startup d’État, tu participeras à l’aventure d’une nouvelle vision de l’administration, moderne et proche de ses usagers.
+Tu es développeur ou développeuse et tu veux mettre tes compétences au profit de l’amélioration du service public ? Tu es à ton aise dans les contextes de petites équipes autonomes, agiles, et proches de leurs utilisateurs ? En rejoignant une Startup d’État, tu participeras à l’aventure d’une nouvelle vision de l’administration, moderne et proche de ses usagers.
 
 ## La mission : Simplifier les échanges entre les juridictions financières et ses interlocuteurs.
 
 La Start-up d’État « e-contrôle » a pour objectif de faciliter les échanges et la communication entre les équipes des juridictions financières (Cour des comptes, Chambres régionales et territoriales des comptes, Cour de discipline budgétaire et financière) et les organismes contrôlés/justiciables, via un produit numérique qui est en cours de construction et déjà expérimenté.
 
-L’équipe « e-contrôle » cherche un·e développeur·se pour des besoins en frontend (mais aussi en backend) pour une mission de 5 mois afin de construire avec l’équipe actuelle un produit visant à rendre service aux agents des juridictions financières et des justiciables ou organismes contrôlés. Il ou elle participera au développement du produit « from scratch ».
+L’équipe « e-contrôle » cherche un développeur ou une développeuse pour des besoins en frontend (mais aussi en backend) pour une mission de 5 mois afin de construire avec l’équipe actuelle un produit visant à rendre service aux agents des juridictions financières et des justiciables ou organismes contrôlés. Il ou elle participera au développement du produit « from scratch ».
 
 ## Compétences et expériences
 
@@ -29,7 +32,7 @@ L’équipe « e-contrôle » cherche un·e développeur·se pour des besoins en
 
 ## Modalités
 
-- Mission proposée pour un·e prestataire ou un·e indépendant·e (en portage).
+- Mission proposée un ou une prestataire ou un indépendant ou une indépendante (en portage).
 - Travail en présentiel possible à la Cour des comptes ou télétravail partiel, avec un jour par semaine à Paris pour retrouver toute l’équipe.
 
 ## Postuler

--- a/content/_jobs/2019-02-15-domifa-dev-fullstack.md
+++ b/content/_jobs/2019-02-15-domifa-dev-fullstack.md
@@ -1,11 +1,11 @@
 ---
-roles: un·e développeur·e full stack
+roles: un développeur ou une développeuse full stack
 startup: domifa
 techno: Choix technologiques ouverts parmi les solutions libres du marché
 open: true
 ---
 
-*DomiFa (Domiciliation Facilitée), une des startups d'État du ministère des Solidarités et de la Santé, cherche un·e développeur·e pour améliorer l'accès aux droits des personnes sans domicile stable.*
+*DomiFa (Domiciliation Facilitée), une des startups d'État du ministère des Solidarités et de la Santé, cherche un développeur ou une développeuse pour améliorer l'accès aux droits des personnes sans domicile stable.*
 
 <!--more-->
 
@@ -25,13 +25,13 @@ La Startup d'État a démarré début janvier 2019. Un premier travail terrain a
 
 ## Le Poste
 
-Vous êtes développeur·e full stack et voulez mettre vos compétences au profit de l’amélioration du service public ?
+Vous êtes développeur ou développeuse full stack et voulez mettre vos compétences au profit de l’amélioration du service public ?
 
 Vous êtes à votre aise dans les contextes de petites équipes autonomes, agiles, et proches de leurs utilisateurs ?
 
 Vous avez à cœur de rendre un service de qualité qui transforme la relation des usagers aux services publics, y compris en outillant des contributeurs/ré-utilisateurs potentiellement peu à l’aise avec le développement logiciel ?
 
-En rejoignant une Startup d'État, vous participez à l’aventure d’une nouvelle vision de  l’administration, moderne et proche de ses usagers.
+En rejoignant une Startup d'État, vous participez à l’aventure d’une nouvelle vision de l’administration, moderne et proche de ses usagers.
 
 ## Responsabilités
 
@@ -57,7 +57,7 @@ Expérience de l’écosystème technique web : test AB, analytics, etc.
 
 ## Modalités
 
-Poste ouvert pour un·e indépendant·e pour un premier contrat de 3 mois renouvelable.
+Poste ouvert pour un indépendant ou une indépendante pour un premier contrat de 3 mois renouvelable.
 Une présence régulière à Paris est demandée pour participer aux sessions communes de tests utilisateurs, démonstrations, rétrospective et planification. Le télétravail est possible.
 Temps partiel accepté (80 % minimum).
 Démarrage des projets fin février - début mars.

--- a/content/_jobs/2019-02-21-bizdev-stage-MRS.md
+++ b/content/_jobs/2019-02-21-bizdev-stage-MRS.md
@@ -1,10 +1,10 @@
 ---
-roles: un·e chargé·e de développement (stage)
+roles: un chargé ou une chargée de développement (stage)
 startup: mrs
 open: true
 ---
 
-La Startup d’État Mes Remboursements Simplifiés (MRS) de la Caisse Primaire d'Assurance Maladie (CPAM) de la Haute-Garonne recherche un·e chargé·e de développement en stage pour intégrer l’équipe MRS.
+La Startup d’État Mes Remboursements Simplifiés (MRS) de la Caisse Primaire d'Assurance Maladie (CPAM) de la Haute-Garonne propose un stage pour un chargé ou une chargée de développement.
 
 <!--more-->
 


### PR DESCRIPTION
- Retire la graphie inclusive point médian des offres de recrutement actuellement ouvertes
- Modifie le template en conséquence
- Améliore le système de tags des technologies sur les offres d'emploi

Il s'agit d'une expérimentation en rapport avec l'envoi de la prochaine newsletter.