### PR TITLE
Réparer les noms sur la page communauté

### DIFF
--- a/content/_authors/antonin.garrone.md
+++ b/content/_authors/antonin.garrone.md
@@ -7,5 +7,4 @@ start: 2019-01-14
 end: 2019-07-13
 employer: dinsic
 startups:
-  - openfisca
 ---

--- a/content/_authors/ivan.collombet.md
+++ b/content/_authors/ivan.collombet.md
@@ -9,7 +9,7 @@ startups:
   - reso
   - signaux-faibles
   - competences-pro
-  - trouve-ta-voie
+  - diagoriente
   - signalement
   - lapins
 previously:

--- a/content/_authors/mahdi.hellal.md
+++ b/content/_authors/mahdi.hellal.md
@@ -7,5 +7,5 @@ start: 2018-12-15
 end: 2019-12-31
 employer: independent
 startups:
-  - trouve-ta-voie
+  - diagoriente
 ---

--- a/content/_authors/sebastian.sachetti.md
+++ b/content/_authors/sebastian.sachetti.md
@@ -12,7 +12,6 @@ previously:
   - demarches-simplifiees.fr
   - aplus
   - api-particulier
-  - franceconnect-agent
 ---
 
 Interface Humaine à la recherche de connections pour développer les services publics numériques de demain


### PR DESCRIPTION
Répare les noms des startups sur la page communauté pour plusieurs auteurs.