### PR TITLE
Remplissage des technologies pour le projet Signalement

### DIFF
--- a/content/_startups/signalement.md
+++ b/content/_startups/signalement.md
@@ -10,6 +10,13 @@ link: https://signalconso.beta.gouv.fr
 repository:
 stats: false
 contact: magali.marcel@beta.gouv.fr
+techno:
+  - Scala
+  - TypeScript
+  - PostgreSQL
+  - Play Framework
+  - Angular
+  - Clever Cloud
 ---
 
 Trop d'anomalies aujourd'hui ne sont pas remontées


### PR DESCRIPTION
Ajout de la partie techno dans le markdown qui décrit la startup Signalement (SignalConso)