### PR TITLE
Ré-activation de l'annonce de recrutement demarches-simplifiees.fr

### DIFF
--- a/content/_jobs/2019-03-19-developpeur-developpeuse-ds.md
+++ b/content/_jobs/2019-03-19-developpeur-developpeuse-ds.md
@@ -1,0 +1,51 @@
+---
+roles: un·e développeur·se
+startup: demarches-simplifiees.fr
+techno: Ruby on Rails
+open: true
+---
+
+L’équipe demarches-simplifiees.fr cherche un·e développeur·se Ruby on Rails freelance pour l’aider à développer de nouvelles fonctionnalités et faciliter la dématérialisation des démarches publiques.
+
+<!--more-->
+
+## demarches-simplifiees.fr
+
+demarches-simplifiees.fr est un outil qui permet aux administrations de dématérialiser leurs démarches papiers. Nous faisons ainsi gagner du temps aux services instructeurs et aux usagers.
+
+L’application est structurée en 3 parties :
+
+- une partie administrateur, qui permet la création de formulaires ;
+- une partie usager, qui permet de remplir un formulaire et de déposer son dossier ;
+- une partie instructeur, qui permet d’instruire les dossiers.
+
+Nous exposons aussi une API pour permettre aux administrations de faire des traitements automatisés.
+
+Nous sommes une équipe de 10 personnes dont 4 devs. Nous faisons des itérations courtes. Nous rencontrons souvent les administrations qui utilisent notre produit, et nous participons au support client afin de mieux nous confronter aux problèmes rencontrés par nos utilisateurs.
+
+## Où en sommes-nous ?
+
+Nous avons jusqu’à présent permis la dématérialisation de plus de 5 000 démarches papier, et près de 200 000 dossiers – mais un nombre très important de démarches restent à dématérialiser. Afin de répondre aux attentes des administrations et des usagers, nous améliorons continuellement le fonctionnement, l’ergonomie et l’accessibilité du produit.
+
+Nous connaissons également en ce moment une forte croissance, et devons améliorer notre base de code et notre infrastructure, afin d’avoir de meilleures performances et de sécuriser les échanges et les données.
+
+Enfin nous animons une petite communauté de contributeurs externes qui participent eux-aussi au développement de l’outil.
+
+## Stack
+
+- Technos : Rails 5, RSpec.
+- Outils : GitHub, CircleCI, Sentry, Kibana, HelpScout.
+- Code ouvert et libre : [https://github.com/betagouv/tps](https://github.com/betagouv/tps).
+- Bonnes pratiques : nous testons notre code, nous faisons des reviews systématiques, nous déployons souvent et par petits lots.
+
+## Rôle
+
+- Déveloper de nouvelles fonctionnalités ;
+- Analyser et résoudre les problèmes d’usabilité les plus fréquents ;
+- Maintenir et faire évoluer notre API.
+
+## Postuler
+
+Pour postuler, [contactez-nous par email](mailto:contact@demarches-simplifiees.fr).
+
+Le profil de poste est flexible : nous recrutons tous types de profils. Si vous hésitez à postuler, écrivez nous quand même.

--- a/content/_jobs/2019-03-19-devops-ds.md
+++ b/content/_jobs/2019-03-19-devops-ds.md
@@ -1,0 +1,53 @@
+---
+roles: un·e devops
+startup: demarches-simplifiees.fr
+techno: Ruby on Rails, Ansible
+open: true
+---
+
+L’équipe demarches-simplifiees.fr cherche un·e DevOps Ruby on Rails indépendant·e pour l’aider à développer de nouvelles fonctionnalités et faciliter la dématérialisation des démarches publiques.
+
+<!--more-->
+
+## demarches-simplifiees.fr
+
+demarches-simplifiees.fr est un outil qui permet aux administrations de dématérialiser leurs démarches papiers. Nous faisons ainsi gagner du temps aux services instructeurs et aux usagers.
+
+L’application est structurée en 3 parties :
+
+- une partie administrateur, qui permet la création de formulaires ;
+- une partie usager, qui permet de remplir un formulaire et de déposer son dossier ;
+- une partie instructeur, qui permet d’instruire les dossiers.
+
+Nous exposons aussi une API pour permettre aux administrations de faire des traitements automatisés.
+
+Nous sommes une équipe de 10 personnes dont 4 devs. Nous faisons des itérations courtes. Nous rencontrons souvent les administrations qui utilisent notre produit, et nous participons au support client afin de mieux nous confronter aux problèmes rencontrés par nos utilisateurs.
+
+## Où en sommes-nous ?
+
+Nous avons jusqu’à présent permis la dématérialisation de plus de 5 000 démarches papier, et près de 200 000 dossiers – mais un nombre très important de démarches restent à dématérialiser. Afin de répondre aux attentes des administrations et des usagers, nous améliorons continuellement le fonctionnement, l’ergonomie et l’accessibilité des outils.
+
+Nous connaissons également en ce moment une forte croissance, et devons améliorer notre base de code et notre infrastructure, afin d’avoir de meilleures performances et de sécuriser les échanges et les données.
+
+Enfin nous animons une petite communauté de contributeurs externes qui participent eux-aussi au développement de l’outil.
+
+## Stack
+
+- Technos : Rails 5, RSpec, Ansible.
+- Outils : GitHub, CircleCI, Nginx, PostgreSQL, Kibana, Grafana, Telegraf.
+- Infrastructure : machines bare-metal OVH.
+- Code ouvert et libre : [https://github.com/betagouv/tps](https://github.com/betagouv/tps).
+- Bonnes pratiques : nous testons notre code, nous faisons des reviews systématiques, nous déployons souvent et par petits lots.
+
+## Rôle
+
+- Déveloper de nouvelles fonctionnalités ;
+- Maintenir et faire évoluer notre API ;
+- Définition du périmètre de sécurité en relation avec la DINSIC et l’ANSII ;
+- Conception, sécurisation et implémentation de notre infrastructure technique.
+
+## Postuler
+
+Pour postuler, [contactez-nous par email](mailto:contact@demarches-simplifiees.fr).
+
+Le profil de poste est flexible : nous recrutons tous types de profils. Si vous hésitez à postuler, écrivez nous quand même.


### PR DESCRIPTION
Demarches-simplifiees.fr recrute à nouveau des développeur·euse·s Rails : cette PR ré-active l'annonce et met à jour le descriptif.

@ la team DS, vous en pensez quoi ?
