### PR TITLE
Fiche de poste pour le dev Archifiltre

### DIFF
--- a/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
+++ b/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
@@ -1,0 +1,66 @@
+---
+roles: un·e développeur·e full stack
+startup: archifiltre
+techno: bon niveau en JavaScript souhaité
+open: false
+---
+
+Archifiltre, une des startups d'État du ministère des Solidarités et de la Santé, cherche un·e développeur·e pour améliorer son produit .\_
+
+<!--more-->
+
+## Qui sommes-nous ?
+
+ArchiFiltre a démarré en 2018 grâce au soutien d’Etalab dans le cadre du programme EIG (Entrepreneur.e.s d’intérêt général) pour 10 mois de développement (Une présentation du défi de la 2ème promotion des EIG est disponible ici: https://entrepreneur-interet-general.etalab.gouv.fr/defis/2018/archifiltre.html). Depuis le mois de mars 2019, ArchiFiltre a rejoint l’incubateur des ministères sociaux et est devenue une startups d'État.
+
+L’objectif d’ArchiFiltre est de proposer à tout utilisateur de fichiers bureautiques un outil de visualisation d’arborescences complètes afin de pouvoir les appréhender rapidement et donc pouvoir les décrire, les enrichir, les organiser et aussi les trier. Pour les utilisateurs de profil archiviste, l’outil permet de réaliser à la fin du traitement un paquet au format SEDA (standard d’échange de données pour l’archivage), format d’entrée des documents et leurs métadonnées dans un système d’archivage électronique.
+
+L’outil déjà développé est un outil libre et ouvert, disponible sur https://archifiltre.github.io/. La v10 est la dernière version aboutie de l’outil qui s’exécute en local. La v8 fonctionne, elle, sur navigateur Internet (Chrome de préférence). Ces deux versions continueront à exister et à être enrichies de nouvelles fonctionnalités en parallèle.
+
+Les développements réalisés en 2018 ont associé un cercle large d’utilisateurs, archivistes principalement, issus de ministères, établissements publics, collectivités territoriales ou entreprises. La priorisation des développements est donc basée sur ce réseau d’utilisateurs coordonné par le bureau des archives des ministères sociaux.
+
+L’outil sur lequel nous travaillons dans le cadre de la startup devra approfondir les fonctionnalités proposées dans les 1ères versions mises en ligne: améliorer les performances pour permettre des analyses de volumes de fichiers plus importants (au-delà de 250 Go), proposer d’autres types de visualisation (à plat ou en pondérant l’importance des fichiers différemment), améliorer la visualisation existante (pour les éléments de petit volume par exemple), prendre en compte les demandes d’amélioration de l’UX/UI, élargir les fonctionnalités actuellement disponibles dans l’outil (comme le taggage, le lien avec des référentiels et l’ajout de certaines métadonnées). L’objectif est maintenant de proposer de nouvelles versions régulières de cet outil pendant l’année 2019 en continuant de prendre en compte les besoins exprimés par les utilisateurs et en améliorant également l’animation du réseau des utilisateurs.
+
+## Le Poste
+
+Vous êtes développeur full stack, et voulez mettre vos compétences au profit de l’amélioration du service public ?
+
+Vous êtes à votre aise dans les contextes de petites équipes autonomes, agiles, et proches de leurs utilisateurs ?
+
+Vous avez à cœur de rendre un service de qualité qui transforme la relation des usagers aux services publics, y compris en outillant des contributeurs/ré-utilisateurs potentiellement peu à l’aise avec le développement logiciel ?
+
+En rejoignant une Startup d'État, vous participez à l’aventure d’une nouvelle vision de l’administration, moderne et proche de ses usagers.
+
+## Responsabilités
+
+Vous serez en charge d’enrichir le produit pour nos utilisateurs. Les choix technologiques sont Webpack, Babel, Css, Html5, Javascript (ECMAScript 6), ElectronJs, ReactJs, Foundation (Framework css), Docker, Yarn/Npm, NodeJs, Git/Github.
+
+Vous pourrez participer à la conception, aux études terrain, aux tests utilisateur avec les intrapreneurs.
+
+Vous êtes entièrement en charge des développements de l’administration système au css, en passant par la mise en place des outils de déploiement, d’intégration continue, de tests, de monitoring.
+
+Vous êtes en mesure de jouer sur 2 tableaux :
+La découverte : « Vite un prototype pour tester une hypothèse avec des utilisateurs dès demain ! »
+L’exploitation : « Il est temps de refactorer et de mettre du monitoring sur ce module ! »
+
+## Compétences
+
+Vous avez l’habitude des modalités de contribution du logiciel libre (issues, PR…).
+Développeur web avec une bonne expérience dans (au moins) un framework web moderne (NodeJS, ...).
+Bonne maîtrise du développement front-end (HTML, CSS, React).
+Expérience en conception orientée utilisateur et en expérience utilisateur.
+Expérience de l’écosystème technique web : test AB, analytics…
+Appétence pour l’UX/UI et le design.
+
+## Modalités
+
+Poste ouvert pour un·e indépendant·e pour un premier contrat de 3 mois renouvelable.
+Une présence régulière à Paris est demandée pour participer aux sessions communes de conception, de test utilisateur, démonstration, rétrospective et planification. Le télétravail est possible.
+Temps partiel accepté (80 % minimum).
+
+## Candidater
+
+Expliquez-nous pourquoi vous avez envie de nous rejoindre et envoyez-nous votre LinkedIn / CV et GitHub, le tout à [recrutement@beta.gouv.fr, julien.bouquillon@sg.social.gouv.fr et eric.heijligers@sg.social.gouv.fr](mailto:recrutement@beta.gouv.fr;julien.bouquillon@sg.social.gouv.fr;eric.heijligers@sg.social.gouv.fr).
+
+À bientôt ! 😀
+cra

--- a/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
+++ b/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
@@ -5,7 +5,7 @@ techno: bon niveau en JavaScript souhaité
 open: true
 ---
 
-Archifiltre, une des startups d'État du ministère des Solidarités et de la Santé, cherche un·e développeur·e pour améliorer son produit .\_
+Archifiltre (https://archifiltre.github.io/), une des startups d'État du ministère des Solidarités et de la Santé, cherche un·e développeur·e pour améliorer son produit .\_
 
 <!--more-->
 

--- a/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
+++ b/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
@@ -5,7 +5,7 @@ techno: bon niveau en JavaScript souhaité
 open: true
 ---
 
-Archifiltre (https://archifiltre.github.io/), une des startups d'État du ministère des Solidarités et de la Santé, cherche un·e développeur·e pour améliorer son produit .\_
+Archifiltre (https://archifiltre.github.io/), une des startups d'État du ministère des Solidarités et de la Santé, cherche un·e développeur·e pour améliorer son produit.\_
 
 <!--more-->
 
@@ -40,8 +40,9 @@ Vous pourrez participer à la conception, aux études terrain, aux tests utilisa
 Vous êtes entièrement en charge des développements de l’administration système au css, en passant par la mise en place des outils de déploiement, d’intégration continue, de tests, de monitoring.
 
 Vous êtes en mesure de jouer sur 2 tableaux :
-- La découverte : « Vite une nouvelle version pour tester une hypothèse avec des utilisateurs dès demain ! »  
-- L’exploitation : « Il est temps de refactorer et de mettre du monitoring sur ce module ! »
+
+-   La découverte : « Vite une nouvelle version pour tester une hypothèse avec des utilisateurs dès demain ! »
+-   L’exploitation : « Il est temps de refactorer et de mettre du monitoring sur ce module ! »
 
 ## Compétences
 

--- a/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
+++ b/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
@@ -40,7 +40,7 @@ Vous pourrez participer à la conception, aux études terrain, aux tests utilisa
 Vous êtes entièrement en charge des développements de l’administration système au css, en passant par la mise en place des outils de déploiement, d’intégration continue, de tests, de monitoring.
 
 Vous êtes en mesure de jouer sur 2 tableaux :
-- La découverte : « Vite un prototype pour tester une hypothèse avec des utilisateurs dès demain ! »  
+- La découverte : « Vite une nouvelle version pour tester une hypothèse avec des utilisateurs dès demain ! »  
 - L’exploitation : « Il est temps de refactorer et de mettre du monitoring sur ce module ! »
 
 ## Compétences

--- a/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
+++ b/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
@@ -2,7 +2,7 @@
 roles: un·e développeur·e full stack
 startup: archifiltre
 techno: bon niveau en JavaScript souhaité
-open: false
+open: true
 ---
 
 Archifiltre, une des startups d'État du ministère des Solidarités et de la Santé, cherche un·e développeur·e pour améliorer son produit .\_
@@ -39,17 +39,17 @@ Vous pourrez participer à la conception, aux études terrain, aux tests utilisa
 
 Vous êtes entièrement en charge des développements de l’administration système au css, en passant par la mise en place des outils de déploiement, d’intégration continue, de tests, de monitoring.
 
-Vous êtes en mesure de jouer sur 2 tableaux :
-La découverte : « Vite un prototype pour tester une hypothèse avec des utilisateurs dès demain ! »
+Vous êtes en mesure de jouer sur 2 tableaux :  
+La découverte : « Vite un prototype pour tester une hypothèse avec des utilisateurs dès demain ! »  
 L’exploitation : « Il est temps de refactorer et de mettre du monitoring sur ce module ! »
 
 ## Compétences
 
-Vous avez l’habitude des modalités de contribution du logiciel libre (issues, PR…).
-Développeur web avec une bonne expérience dans (au moins) un framework web moderne (NodeJS, ...).
-Bonne maîtrise du développement front-end (HTML, CSS, React).
-Expérience en conception orientée utilisateur et en expérience utilisateur.
-Expérience de l’écosystème technique web : test AB, analytics…
+Vous avez l’habitude des modalités de contribution du logiciel libre (issues, PR…).  
+Développeur web avec une bonne expérience dans (au moins) un framework web moderne (NodeJS, ...).  
+Bonne maîtrise du développement front-end (HTML, CSS, React).  
+Expérience en conception orientée utilisateur et en expérience utilisateur.  
+Expérience de l’écosystème technique web : test AB, analytics…  
 Appétence pour l’UX/UI et le design.
 
 ## Modalités

--- a/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
+++ b/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
@@ -1,6 +1,6 @@
 ---
 roles: un·e développeur·e full stack
-startup: archifiltre
+startup: Archifiltre
 techno: bon niveau en JavaScript souhaité
 open: true
 ---
@@ -40,8 +40,8 @@ Vous pourrez participer à la conception, aux études terrain, aux tests utilisa
 Vous êtes entièrement en charge des développements de l’administration système au css, en passant par la mise en place des outils de déploiement, d’intégration continue, de tests, de monitoring.
 
 Vous êtes en mesure de jouer sur 2 tableaux :  
-La découverte : « Vite un prototype pour tester une hypothèse avec des utilisateurs dès demain ! »  
-L’exploitation : « Il est temps de refactorer et de mettre du monitoring sur ce module ! »
+- La découverte : « Vite un prototype pour tester une hypothèse avec des utilisateurs dès demain ! »  
+- L’exploitation : « Il est temps de refactorer et de mettre du monitoring sur ce module ! »
 
 ## Compétences
 
@@ -63,4 +63,3 @@ Temps partiel accepté (80 % minimum).
 Expliquez-nous pourquoi vous avez envie de nous rejoindre et envoyez-nous votre LinkedIn / CV et GitHub, le tout à [recrutement@beta.gouv.fr, julien.bouquillon@sg.social.gouv.fr et eric.heijligers@sg.social.gouv.fr](mailto:recrutement@beta.gouv.fr;julien.bouquillon@sg.social.gouv.fr;eric.heijligers@sg.social.gouv.fr).
 
 À bientôt ! 😀
-cra

--- a/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
+++ b/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
@@ -54,8 +54,8 @@ Appétence pour l’UX/UI et le design.
 
 ## Modalités
 
-Poste ouvert pour un·e indépendant·e pour un premier contrat de 3 mois renouvelable.
-Une présence régulière à Paris est demandée pour participer aux sessions communes de conception, de test utilisateur, démonstration, rétrospective et planification. Le télétravail est possible.
+Poste ouvert pour un·e indépendant·e pour un premier contrat de 3 mois renouvelable.  
+Une présence régulière à Paris est demandée pour participer aux sessions communes de conception, de test utilisateur, démonstration, rétrospective et planification. Le télétravail est possible.  
 Temps partiel accepté (80 % minimum).
 
 ## Candidater

--- a/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
+++ b/content/_jobs/2019-03-22-archifiltre-dev-fullstack.md
@@ -39,7 +39,7 @@ Vous pourrez participer à la conception, aux études terrain, aux tests utilisa
 
 Vous êtes entièrement en charge des développements de l’administration système au css, en passant par la mise en place des outils de déploiement, d’intégration continue, de tests, de monitoring.
 
-Vous êtes en mesure de jouer sur 2 tableaux :  
+Vous êtes en mesure de jouer sur 2 tableaux :
 - La découverte : « Vite un prototype pour tester une hypothèse avec des utilisateurs dès demain ! »  
 - L’exploitation : « Il est temps de refactorer et de mettre du monitoring sur ce module ! »
 

--- a/content/_startups/archifiltre.md
+++ b/content/_startups/archifiltre.md
@@ -1,0 +1,45 @@
+---
+title: Archifiltre
+mission: Vos arborescences de fichiers bureautiques comme vous ne les avez jamais vues
+owner: Ministère des Solidarités et de la Santé
+incubator: sgmas
+status: acceleration
+start: 2019-04-01
+end:
+link: https://archifiltre.github.io/
+repository:
+stats: false
+contact: chloe.moser@sg.social.gouv.fr
+---
+
+##Nos origines
+
+Dans toutes les organisations, la dette de documents numériques produits et non triés augmente de manière exponentielle et incontrôlée. L’absence de représentation visuelle de ces masses de documents amène tout producteur de fichiers bureautiques à continuer à stocker, sans parfois en maîtriser le contenu, des strates et des strates de fichiers. Cette accumulation souvent anarchique s’accentue avec l’utilisation de serveurs de fichiers partagés dont la capacité de stockage augmente au fur et à mesure que les coûts de stockage diminuent.
+Les archivistes des ministères sociaux étant confrontés à cette production de documents de manière particulièrement accrue depuis quelques années, elle.il.s ont voulu se doter d’un outil pour leur permettre de relever le défi du tri et de la description de ces arborescences de fichiers.
+C’est dans le cadre de cette réflexion qu’ArchiFiltre a démarré en 2018 grâce au soutien d’Etalab dans le cadre de la 2ème promotion du programme EIG (Entrepreneur.e.s d’intérêt général) pour 10 mois de développement (Voir https://entrepreneur-interet-general.etalab.gouv.fr/defis/2018/archifiltre.html pour davantage d’informations). Depuis le mois de mars 2019, ArchiFiltre a rejoint l’incubateur des ministères sociaux et est devenue une startup d'État pour poursuivre les travaux entamés.
+
+##Nos objectifs
+
+L’objectif d’ArchiFiltre est de proposer à tout utilisateur de fichiers bureautiques un outil de visualisation d’arborescences complètes afin de pouvoir les appréhender rapidement en vue de les décrire, les organiser, les trier et aussi les enrichir en apportant de la contextualisation et de la qualification aux documents.
+Pour les utilisateurs de profil archiviste, l’outil permet de réaliser à la fin du traitement un paquet au format SEDA (standard d’échange de données pour l’archivage), format d’entrée des documents et leurs métadonnées dans un système d’archivage électronique.
+Pour les utilisateurs de profil producteur de documents, l’outil est une aide à la compréhension à un niveau macro d’arborescences complètes de fichiers pour pouvoir mieux les comprendre, les maîtriser et donc les gérer.
+Notre objectif est simple… Sauver le monde de l’information bureautique!
+
+##Nos réalisations
+
+L’outil déjà développé est un outil libre et ouvert, disponible sur https://archifiltre.github.io/. La v10 est la dernière version aboutie de l’outil qui s’exécute en local. La v8 fonctionne, elle, sur navigateur Internet (Chrome de préférence). Ces deux versions continueront à exister et à être enrichies de nouvelles fonctionnalités en parallèle car elles répondent à la diversité des utilisateurs en terme d’équipements informatiques.
+
+##Nos utilisateurs
+
+ArchiFiltre est un produit imaginé pour correspondre aux besoins des ministères sociaux mais aussi à ceux d’un réseau large et dynamique d’archivistes présents tant dans le secteur public que privé. Les développements réalisés en 2018 ont associé de nombreux utilisateurs, archivistes principalement, issus de ministères, établissements publics, collectivités territoriales ou entreprises. La priorisation des développements est donc basée sur ce réseau d’utilisateurs coordonné par le bureau des archives des ministères sociaux mais nous souhaitons également associer davantage d’autres profils et d’autres archivistes, l’appréhension d’arborescences de fichiers concernant tout producteur de documents bureautiques.
+
+##Nos prochains développements
+
+L’outil sur lequel nous travaillons dans le cadre de la startup devra approfondir les fonctionnalités proposées dans les 1ères versions mises en ligne: améliorer les performances pour permettre des analyses de volumes de fichiers plus importants (au-delà de 250 Go), proposer d’autres types de visualisation (à plat ou en pondérant l’importance des fichiers différemment), améliorer la visualisation existante (pour les éléments de petit volume par exemple), prendre en compte les demandes d’amélioration de l’UX/UI, élargir les fonctionnalités actuellement disponibles dans l’outil (comme le taggage, le lien avec des référentiels et l’ajout de certaines métadonnées). L’objectif est maintenant de proposer de nouvelles versions régulières de cet outil pendant l’année 2019 en continuant de prendre en compte les besoins exprimés par les utilisateurs et en améliorant également l’animation du réseau des utilisateurs.
+Cette démarche doit également tenir compte de l’intégration du produit ArchiFiltre dans un écosystème en cours de construction autour de l’archivage électronique des données publiques.
+
+Les liens utiles du projet
+Site: https://archifiltre.github.io/
+Github: https://socialgouv.github.io/archifiltre
+Twitter: https://twitter.com/archifiltre?lang=fr
+Mail: archifiltre@data.gouv.fr


### PR DESCRIPTION
Archifiltre c'est ça : https://archifiltre.github.io/
Ca a été créé par des EIG de la saison 2 et c'est l'incubateur des ministères sociaux qui reprend le flambeau.
🙂
