### PR TITLE
Temporary banner on the jobs page for the Tech Meetup

### DIFF
--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -5,6 +5,13 @@ layout: default
 {% assign lang = page.lang | default: site.lang | default: "fr" %}
 <div class="page article">
   {% include hero-page.html title=page.title %}
+  <div class="container">
+    <blockquote>
+      <p>
+        Les développeurs de Beta Gouv organisent leur premier <a href="https://www.eventbrite.fr/preview?eid=59297040043">Meetup Tech</a> le 11 avril à Paris. C'est ouvert à tous, n'hésitez pas à venir et discuter avec nous !
+      </p>
+    </blockquote>
+  </div>
   <section class="section section-white cards">
     <div class="container jobs">
       <h3>Offres disponibles</h3>

--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -6,7 +6,7 @@ layout: default
 <div class="page article">
   {% include hero-page.html title=page.title %}
   <div class="notification full-width">
-    Les développeurs de Beta Gouv organisent leur premier <a href="https://www.eventbrite.fr/preview?eid=59297040043">Meetup Tech</a> le 11 avril à Paris. C'est ouvert à tous, n'hésitez pas à venir et discuter avec nous !
+    Les développeurs de beta.gouv.fr organisent leur premier <a href="https://www.eventbrite.fr/preview?eid=59297040043">Meetup Tech</a> le 11 avril à Paris. C'est ouvert à tous, n'hésitez pas à venir et discuter avec nous !
   </div>
   <section class="section section-white cards">
     <div class="container jobs">

--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -6,7 +6,7 @@ layout: default
 <div class="page article">
   {% include hero-page.html title=page.title %}
   <div class="notification full-width">
-    Les développeurs de Beta.gouv.fr organisent leur premier <a href="https://www.eventbrite.fr/e/billets-meetup-tech-betagouvfr-x-latitudes-59297040043">Meetup Tech</a> le 11 avril à Paris en partenariat avec Latitudes. C'est ouvert à tous, n'hésitez pas à venir discuter avec nous !
+    Les développeurs de beta.gouv.fr organisent leur premier <a href="https://www.eventbrite.fr/e/billets-meetup-tech-betagouvfr-x-latitudes-59297040043">Meetup Tech</a> le 11 avril à Paris en partenariat avec Latitudes. C'est ouvert à tous, n'hésitez pas à venir discuter avec nous !
   </div>
   <section class="section section-white cards">
     <div class="container jobs">

--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -5,12 +5,8 @@ layout: default
 {% assign lang = page.lang | default: site.lang | default: "fr" %}
 <div class="page article">
   {% include hero-page.html title=page.title %}
-  <div class="container">
-    <blockquote>
-      <p>
-        Les développeurs de Beta Gouv organisent leur premier <a href="https://www.eventbrite.fr/preview?eid=59297040043">Meetup Tech</a> le 11 avril à Paris. C'est ouvert à tous, n'hésitez pas à venir et discuter avec nous !
-      </p>
-    </blockquote>
+  <div class="notification full-width">
+    Les développeurs de Beta Gouv organisent leur premier <a href="https://www.eventbrite.fr/preview?eid=59297040043">Meetup Tech</a> le 11 avril à Paris. C'est ouvert à tous, n'hésitez pas à venir et discuter avec nous !
   </div>
   <section class="section section-white cards">
     <div class="container jobs">

--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -6,7 +6,7 @@ layout: default
 <div class="page article">
   {% include hero-page.html title=page.title %}
   <div class="notification full-width">
-    Les développeurs de beta.gouv.fr organisent leur premier <a href="https://www.eventbrite.fr/preview?eid=59297040043">Meetup Tech</a> le 11 avril à Paris. C'est ouvert à tous, n'hésitez pas à venir et discuter avec nous !
+    Les développeurs de Beta.gouv.fr organisent leur premier <a href="https://www.eventbrite.fr/e/billets-meetup-tech-betagouvfr-x-latitudes-59297040043">Meetup Tech</a> le 11 avril à Paris en partenariat avec Latitudes. C'est ouvert à tous, n'hésitez pas à venir discuter avec nous !
   </div>
   <section class="section section-white cards">
     <div class="container jobs">


### PR DESCRIPTION
Sur suggestion d'Anna Livia, on propose d'ajouter une bannière temporaire sur la page recrutement au sujet du meetup tech en organisation. Ca sera le 11 avril donc c'est vraiment temporaire.

j'ai réutilisé le composant `notification` utilisé sur les pages de jobs en détail.

![Capture d’écran - 2019-03-24 à 21 42 52](https://user-images.githubusercontent.com/883348/54885583-03510d00-4e7e-11e9-91eb-efd024e8a686.png)


(c'est pas moi qui ait cassé le menu 😬 )

C'est pas incroyable mais ça fait le job et encore une fois ça disparaît le 12 avril. On verra si le meetup se pérennise par la suite on pourra faire quelque chose de plus joli ou plus détaillé.