### PR TITLE
Automatisation des avatars Github

### DIFF
--- a/_includes/avatar.html
+++ b/_includes/avatar.html
@@ -11,6 +11,11 @@
   <img class="screenshot lozad" data-src="{{ screenshot_path }}" title="{{ include.author.fullname }}" alt="" data-proofer-ignore>
 {% elsif include.author.avatar %}
   <img class="screenshot lozad" data-src="{{ include.author.avatar }}" title="{{ include.author.fullname }}" alt="" data-proofer-ignore>
+{% elsif include.author.github %}
+  {% capture avatarGithub %}
+    https://avatars3.githubusercontent.com/{{include.author.github}}?s=600
+  {% endcapture %}
+  <img class="screenshot lozad" data-src="{{ avatarGithub }}" title="{{ include.author.fullname }}" alt="" data-proofer-ignore>
 {% elsif include.force %}
   {% assign screenshot_path = "/img/logo-generique-startup-carre.jpg" %}
   <img class="screenshot lozad" data-src="{{ screenshot_path }}" title="{{ include.author.fullname }}" alt="" data-proofer-ignore>

--- a/content/_authors/adeline.latron.md
+++ b/content/_authors/adeline.latron.md
@@ -1,13 +1,12 @@
 ---
 fullname: Adeline Latron
 role: Chargée de développement
-avatar: https://avatars3.githubusercontent.com/adeline-lrn?s=600
 github: adeline-lrn
 start: 2019-02-07
 end: 2019-12-31
 employer: independent
-startups: 
+startups:
     - place-des-entreprises
----
+---²
 
 "Le progrès ne vaut que s'il est partagé par tous" Aristote

--- a/content/_authors/adeline.latron.md
+++ b/content/_authors/adeline.latron.md
@@ -7,6 +7,6 @@ end: 2019-12-31
 employer: independent
 startups:
     - place-des-entreprises
----²
+---
 
 "Le progrès ne vaut que s'il est partagé par tous" Aristote

--- a/content/_authors/adrien.di_pasquale.md
+++ b/content/_authors/adrien.di_pasquale.md
@@ -1,7 +1,6 @@
 ---
 fullname: Adrien Di Pasquale
 role: Développeur Fullstack
-avatar: https://avatars3.githubusercontent.com/adipasquale?s=600
 link: https://adrien.dipasquale.fr
 github: adipasquale
 start: 2019-01-14

--- a/content/_authors/amandine.audras.md
+++ b/content/_authors/amandine.audras.md
@@ -1,7 +1,6 @@
 ---
 fullname: Amandine Audras
 role: UX Designer
-avatar: https://avatars3.githubusercontent.com/renardpal?s=600
 link: https://renardpal.com
 github: renardpal
 start: 2018-11-02

--- a/content/_authors/anis.safine.md
+++ b/content/_authors/anis.safine.md
@@ -1,7 +1,6 @@
 ---
-fullname: Anis Safine 
+fullname: Anis Safine
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/anis?s=600
 github: anis
 start: 2018-11-19
 end: 2019-03-31

--- a/content/_authors/antoine.bigard.md
+++ b/content/_authors/antoine.bigard.md
@@ -1,7 +1,6 @@
 ---
 fullname: Antoine Bigard
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/gethi
 github: gethi
 start: 2018-09-17
 employer: independent/octo

--- a/content/_authors/arnaud.denoix.md
+++ b/content/_authors/arnaud.denoix.md
@@ -1,7 +1,6 @@
 ---
 fullname: Arnaud Denoix
-role: Coach 
-avatar: https://avatars3.githubusercontent.com/adenoix?s=600
+role: Coach
 github: adenoix
 start: 2018-12-07
 employer: independent/dinsic
@@ -10,5 +9,3 @@ startups:
   - la-bonne-formation
   - memo
 ---
-
-

--- a/content/_authors/arnaud.meunier.md
+++ b/content/_authors/arnaud.meunier.md
@@ -1,7 +1,6 @@
 ---
 fullname: Arnaud Meunier
-role: Coach 
-avatar: https://avatars0.githubusercontent.com/u/292753?s=600
+role: Coach
 github: arnaudmeunier
 start: 2019-03-22
 end: 2019-07-31

--- a/content/_authors/augustin.wenger.md
+++ b/content/_authors/augustin.wenger.md
@@ -1,7 +1,6 @@
 ---
 fullname: Augustin Wenger
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/magemax?s=600
 link:
 github: magemax
 start: 2019-01-21

--- a/content/_authors/bastien.gillet.md
+++ b/content/_authors/bastien.gillet.md
@@ -1,7 +1,6 @@
 ---
 fullname: Bastien Gillet
 role: Designer UI / UX
-avatar: https://avatars2.githubusercontent.com/u/38954696?s=460&v=4
 github: bastienCap
 start: 2018-04-24
 end: 2018-10-01

--- a/content/_authors/beatrice.mercier.md
+++ b/content/_authors/beatrice.mercier.md
@@ -1,11 +1,10 @@
 ---
 fullname: Beatrice Mercier
-role: Chargée de deploiement 
+role: Chargée de deploiement
 github: be-mercier
-avatar: https://avatars1.githubusercontent.com/u/47319124?s=200&v=4
 start: 2019-02-04 
 end:
-employer: independent/<La Zone> 
+employer: independent/<La Zone>
 startups:
     - transport
 ---

--- a/content/_authors/benjamin.gicquel.md
+++ b/content/_authors/benjamin.gicquel.md
@@ -1,7 +1,6 @@
 ---
 fullname: Benjamin Gicquel
 role: Intrapreneur
-avatar: https://avatars3.githubusercontent.com/benjaminurg?s=600
 github: BenjaminUrg
 start: 2018-11-20
 end: 2019-09-20

--- a/content/_authors/berengere.aujard.md
+++ b/content/_authors/berengere.aujard.md
@@ -1,7 +1,6 @@
 ---
 fullname: Bérengère Aujard
 role: Intrapreneuse
-avatar: https://avatars3.githubusercontent.com/BerengereAujard?s=600
 github: BerengereAujard
 start: 2019-03-13
 end: 2021-10-31

--- a/content/_authors/brice.friederich.md
+++ b/content/_authors/brice.friederich.md
@@ -1,7 +1,6 @@
 ---
 fullname: Brice Friederich
 role: Développeur
-avatar: https://avatars0.githubusercontent.com/u/7509495
 github: bfriederich
 start: 2018-05-22
 end: 2019-04-30

--- a/content/_authors/cecile.comperat.md
+++ b/content/_authors/cecile.comperat.md
@@ -1,7 +1,6 @@
 ---
 fullname: Cécile Compérat
 role: Chargée de développement territorial Hérault
-avatar: https://avatars3.githubusercontent.com/u/9933870?s=460&v=4
 github: ccompera
 start: 2018-04-05
 end: 2019-05-31
@@ -9,4 +8,3 @@ employer: admin/Ministère de la Culture
 startups:
     - pass-culture
 ---
-

--- a/content/_authors/clemence.leurent.md
+++ b/content/_authors/clemence.leurent.md
@@ -1,7 +1,6 @@
 ---
 fullname: Clemence Leurent
 role: Chargée de développement
-avatar: https://avatars3.githubusercontent.com/clemenceleurent?s=600
 github: clemenceleurent
 start: 2018-05-30
 end: 2018-08-30

--- a/content/_authors/clement.camin.md
+++ b/content/_authors/clement.camin.md
@@ -1,7 +1,6 @@
 ---
 fullname: Clément Camin
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/keirua?s=600
 link: https://blog.keiruaprod.fr
 github: keirua
 start: 2018-03-14

--- a/content/_authors/clement.chapalain.md
+++ b/content/_authors/clement.chapalain.md
@@ -1,7 +1,6 @@
 ---
 fullname: Clément Chapalain
 role: Coach
-avatar: https://avatars3.githubusercontent.com/u/5337489?s=400&v=4
 github: ClementChapalain
 start: 2018-09-05
 end: 2019-12-31

--- a/content/_authors/clement.morisset.md
+++ b/content/_authors/clement.morisset.md
@@ -1,15 +1,10 @@
 ---
 fullname: Clément Morisset
 role: Développeur
-# ci-dessous, remplace pseudo_github par ton propre pseudo Github pour utiliser la photo de ton profil
-# tu peux aussi fournir l'URL (HTTPS obligatoire) d'une image carrée 512x512 minimum
-# à défaut, si tu laisses ce champs vide, alors ton avatar sera l'image prenom.nom du dossier /img/authors/
-# si aucune image n'est trouvée, alors la fiole beta.gouv.fr sera utilisée sur le site
-avatar: https://avatars3.githubusercontent.com/morissetcl?s=600
 github: morissetcl
 start: 2019-03-25
-end: 2019-07-31 # date de fin de contrat au format ISO (AAAA-MM-JJ)
+end: 2019-07-31
 employer: service/captive
-startups: # ta ou tes startups actuelles
+startups:
     - competences-pro
 ---

--- a/content/_authors/damien.dufourd.md
+++ b/content/_authors/damien.dufourd.md
@@ -1,7 +1,6 @@
 ---
 fullname: Damien Dufourd
 role: Coach
-avatar: https://avatars3.githubusercontent.com/damiendufourd?s=600
 github: damiendufourd
 start: 2018-09-04
 end: 2019-12-31

--- a/content/_authors/dorine.lambinet.md
+++ b/content/_authors/dorine.lambinet.md
@@ -1,8 +1,6 @@
 ---
 fullname: Dorine Lambinet
 role: Designere
-avatar: https://avatars3.githubusercontent.com/DorineLam?s=600
-link:
 github: DorineLam
 start: 2019-01-21
 end: 2019-11-20
@@ -10,4 +8,3 @@ employer: dinsic
 startups:
   - leximpact
 ---
-

--- a/content/_authors/elise.marion.md
+++ b/content/_authors/elise.marion.md
@@ -1,7 +1,6 @@
 ---
 fullname: Elise Marion
 role: Intrapreneure / "Aides-territoires"
-avatar: https://avatars1.githubusercontent.com/u/30448170?s=400&u=1a96e25e7f0493b204bcc7098c77b7daff0e4c36&v=4
 github: elisemarion
 start: 2018-01-01
 end: 2019-07-01

--- a/content/_authors/emmanuel.gaillot.md
+++ b/content/_authors/emmanuel.gaillot.md
@@ -1,7 +1,6 @@
 ---
 fullname: Emmanuel Gaillot
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/egaillot?s=600
 link: https://ut7.fr
 github: egaillot
 start: 2018-10-24

--- a/content/_authors/eric.westrelin.md
+++ b/content/_authors/eric.westrelin.md
@@ -1,7 +1,6 @@
 ---
 fullname: Eric Westrelin
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/ericwes?s=600
 github: ericwes
 start: 2018-03-27
 end: 2018-05-09

--- a/content/_authors/estelle.comment.md
+++ b/content/_authors/estelle.comment.md
@@ -1,7 +1,6 @@
 ---
 fullname: Estelle Comment
 role: Développeu·r·se
-avatar: https://avatars3.githubusercontent.com/estellecomment
 github: estellecomment
 start: 2019-03-18
 end: 2021-10-31

--- a/content/_authors/etienne.charignon.md
+++ b/content/_authors/etienne.charignon.md
@@ -1,7 +1,6 @@
 ---
 fullname: Étienne Charignon
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/etiennecharignon?s=600
 link: https://ut7.fr
 github: etiennecharignon
 start: 2018-10-24

--- a/content/_authors/franck.coufourier.md
+++ b/content/_authors/franck.coufourier.md
@@ -1,7 +1,6 @@
 ---
 fullname: Franck Coufourier
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/fcoufour?s=600
 github: fcoufour
 start: 2019-01-07
 end: 2019-04-04

--- a/content/_authors/francois-joseph.grimault.md
+++ b/content/_authors/francois-joseph.grimault.md
@@ -1,7 +1,6 @@
 ---
 fullname: François-Joseph Grimault
 role: Coach
-avatar: https://avatars1.githubusercontent.com/u/91435?v=4&size=512
 start: 2017-10-01
 end: 2019-05-31
 employer: independent

--- a/content/_authors/francois.de_metz.md
+++ b/content/_authors/francois.de_metz.md
@@ -3,7 +3,6 @@ fullname: François de Metz
 role: Développeur
 link: https://2metz.fr/
 github: francois2metz
-avatar: https://avatars3.githubusercontent.com/francois2metz?s=600
 start: 2019-02-25
 end: 2019-07-30
 employer: independent

--- a/content/_authors/gaelle.ottan.md
+++ b/content/_authors/gaelle.ottan.md
@@ -1,17 +1,11 @@
 ---
-fullname: Gaëlle Ottan # penser à modifier le nom du fichier ci-dessus en prenom.nom.md !
-role: Chef de produit # Développeu·r·se / Intrapreneu·r·se / Coach / Chargé de développement / ...
-# ci-dessous, remplace pseudo_github par ton propre pseudo Github pour utiliser la photo de ton profil
-# tu peux aussi fournir l'URL (HTTPS obligatoire) d'une image carrée 512x512 minimum
-# à défaut, si tu laisses ce champs vide, alors ton avatar sera l'image prenom.nom du dossier /img/authors/
-# si aucune image n'est trouvée, alors la fiole beta.gouv.fr sera utilisée sur le site
-avatar: https://avatars3.githubusercontent.com/gaelleottan?s=600
-link: # optionnel : lien vers une page perso externe. Effacer cette ligne si rien à mettre.
-github: gaelleottan # optionnel : nom d'utilisateur GitHub, permet d'être ajouté automatiquement à l'organisation GitHub betagouv
-start: 2019-02-28 # date d'arrivée au format ISO (AAAA-MM-JJ)
+fullname: Gaëlle Ottan
+role: Chef de produit
+github: gaelleottan
+start: 2019-02-28
 end:
 employer: independent/ut7
-startups: 
+startups:
     - competences-pro
 previously:
 ---

--- a/content/_authors/gregoire.aubert.md
+++ b/content/_authors/gregoire.aubert.md
@@ -1,7 +1,6 @@
 ---
 fullname: Grégoire Aubert
 role: Chargé de développement
-avatar: https://avatars3.githubusercontent.com/Gregoire-Aubert?s=600
 github: Gregoire-Aubert
 start: 2019-01-14
 end: 2019-07-14

--- a/content/_authors/guillaume.lagorce.md
+++ b/content/_authors/guillaume.lagorce.md
@@ -1,7 +1,6 @@
 ---
 fullname: Guillaume Lagorce
 role: Développeur
-avatar: https://avatars0.githubusercontent.com/u/2989532?s=460&v=4
 github: heygul
 start: 2019-01-01
 end:  2019-12-31

--- a/content/_authors/henri.salomon.md
+++ b/content/_authors/henri.salomon.md
@@ -2,7 +2,6 @@
 fullname: Henri Salomon
 role: Chargé de déploiement
 github: henrisalomon
-avatar: https://avatars3.githubusercontent.com/u/43140124?s=460&v=4
 start: 2018-09-10
 end:  2019-02-28
 employer: independent

--- a/content/_authors/hugo.agbonon.md
+++ b/content/_authors/hugo.agbonon.md
@@ -1,7 +1,6 @@
 ---
 fullname: Hugo Agbonon
 role: Développeur web
-avatar: https://avatars3.githubusercontent.com/codeheroics?s=600
 link: https://www.codeheroics.com
 github: codeheroics
 start: 2018-04-24

--- a/content/_authors/ivan.gabriele.md
+++ b/content/_authors/ivan.gabriele.md
@@ -1,12 +1,11 @@
 ---
 fullname: Ivan Gabriele
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/ivangabriele?s=600
 link: https://github.com/ivangabriele
 github: ivangabriele
 start: 2019-02-12
 end: 2019-12-31
 employer: independent
-startups: 
+startups:
     - codedutravail
 ---

--- a/content/_authors/jean-michel.armand.md
+++ b/content/_authors/jean-michel.armand.md
@@ -1,13 +1,12 @@
 ---
-fullname: Jean-Michel Armand # penser à modifier le nom du fichier ci-dessus en prenom.nom.md !
-role: Développeur # Développeu·r·se / Intrapreneu·r·se / Coach / Chargé de développement / ...
-avatar: https://avatars3.githubusercontent.com/mrjmad?s=600
-github: mrjmad # optionnel : nom d'utilisateur GitHub, permet d'être ajouté automatiquement à l'organisation GitHub betagouv
-start: 2018-12-21 # date d'arrivée au format ISO (AAAA-MM-JJ)
-end: 2019-12-25 # date de fin de contrat au format ISO (AAAA-MM-JJ)
-employer: independent # dinsic ou independent/<employer> ou admin/<employer> ou service/octo
-startups: # ta ou tes startups actuelles
-    - voir-et-localiser # le nom du fichier de la startup dans le répertoire /content/_startups/ sans l'extension .md
+fullname: Jean-Michel Armand
+role: Développeur
+github: mrjmad
+start: 2018-12-21
+end: 2019-12-25
+employer: independent
+startups:
+    - voir-et-localiser
 ---
 
 Code, Django et Cassoulet

--- a/content/_authors/jerome.rivals.md
+++ b/content/_authors/jerome.rivals.md
@@ -1,7 +1,6 @@
 ---
 fullname: Jérôme Rivals
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/jrivals?s=600
 github: jrivals
 start: 2018-11-08
 end: 2019-06-30
@@ -9,4 +8,3 @@ employer: independent/octo
 startups:
     - signalement
 ---
-

--- a/content/_authors/johan.girod.md
+++ b/content/_authors/johan.girod.md
@@ -1,7 +1,6 @@
 ---
 fullname: Johan Girod
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/johangirod?s=600
 link: https://johangirod.com
 github: johangirod
 start: 2018-04-24

--- a/content/_authors/johan.quignard.md
+++ b/content/_authors/johan.quignard.md
@@ -1,7 +1,6 @@
 ---
 fullname: Johan Quignard
 role: Business Developer
-avatar: https://avatars3.githubusercontent.com/Johan1983?s=600
 start: 2017-09-27
 github: Johan1983
 employer: admin/CNAM

--- a/content/_authors/jonathan.fallon.md
+++ b/content/_authors/jonathan.fallon.md
@@ -2,11 +2,9 @@
 fullname: Jonathan Fallon
 role: Développeur
 github: jonathanfallon
-avatar: https://avatars3.githubusercontent.com/u/1656255?s=460&v=4
 start: 2018-11-05
 end: 2019-05-31
 employer: independent/Codeurs en Liberté
 startups:
     - preuve-de-covoiturage
 ---
-

--- a/content/_authors/julien.rayneau.md
+++ b/content/_authors/julien.rayneau.md
@@ -1,12 +1,11 @@
 ---
 fullname: Julien Rayneau
 role: Coach
-avatar: https://avatars3.githubusercontent.com/jrayneau?s=600
 github: jrayneau
 start: 2018-04-10
 end: 2019-12-31
 employer: independent
 startups:
     - place-des-entreprises
-    - signalement 
+    - signalement
 ---

--- a/content/_authors/kevin.andre.md
+++ b/content/_authors/kevin.andre.md
@@ -1,7 +1,6 @@
 ---
 fullname: Kévin André
 role: Coach
-avatar: https://avatars3.githubusercontent.com/KevinAndre?s=600
 link: https://www.linkedin.com/in/kevinandre0/?lipi=urn%3Ali%3Apage%3Ad_flagship3_feed%3B35Krptq%2BRqa2ajP7qa3gTg%3D%3D&licu=urn%3Ali%3Acontrol%3Ad_flagship3_feed-identity_profile_photo
 github: KevinAndre
 start: 2018-04-01

--- a/content/_authors/lery.jicquel.md
+++ b/content/_authors/lery.jicquel.md
@@ -1,7 +1,6 @@
 ---
 fullname: Léry Jicquel
 role: Intrapreneur
-avatar: https://avatars3.githubusercontent.com/LeryJ
 github: LeryJ
 start: 2018-09-01
 end: 2021-03-01

--- a/content/_authors/lionel.breduillieard.md
+++ b/content/_authors/lionel.breduillieard.md
@@ -1,11 +1,10 @@
 ---
 fullname: Lionel Breduillieard
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/lionelb?s=600
 link: http://lumographe.fr
 github: lionelb
 start: 2018-10-08
-end: 2019-03-31 
+end: 2019-03-31
 employer: independent/<octo>
 startups:
     - codedutravail

--- a/content/_authors/mahdi.hellal.md
+++ b/content/_authors/mahdi.hellal.md
@@ -1,7 +1,6 @@
 ---
 fullname: Mahdi Hellal
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/maydon?s=600
 github: maydon
 start: 2018-12-15
 end: 2019-12-31

--- a/content/_authors/martin.fourcade.md
+++ b/content/_authors/martin.fourcade.md
@@ -1,11 +1,6 @@
 ---
 fullname: Martin Fourcade
 role: Développeur
-# ci-dessous, remplace pseudo_github par ton propre pseudo Github pour utiliser la photo de ton profil
-# tu peux aussi fournir l'URL (HTTPS obligatoire) d'une image carrée 512x512 minimum
-# à défaut, si tu laisses ce champs vide, alors ton avatar sera l'image prenom.nom du dossier /img/authors/
-# si aucune image n'est trouvée, alors la fiole beta.gouv.fr sera utilisée sur le site
-avatar: https://avatars3.githubusercontent.com/mfo?s=600
 github: mfo
 start: 2019-02-06
 end: 2019-05-31

--- a/content/_authors/mathieu.agopian.md
+++ b/content/_authors/mathieu.agopian.md
@@ -1,7 +1,6 @@
 ---
 fullname: Mathieu Agopian
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/magopian?s=600
 link: https://agopian.info/
 github: magopian
 start: 2018-10-01

--- a/content/_authors/mathieu.soldano.md
+++ b/content/_authors/mathieu.soldano.md
@@ -1,11 +1,10 @@
 ---
 fullname: Mathieu SOLDANO
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/msoldano?s=600
 github: msoldano
 start: 2018-11-09
 end: 2019-07-01
 employer: admin/MTES-MCT
-startups: 
+startups:
     - aides-territoires
 ---

--- a/content/_authors/matthieu.martin.md
+++ b/content/_authors/matthieu.martin.md
@@ -1,7 +1,6 @@
 ---
 fullname: Matthieu Martin
 role: Illustrateur
-avatar: https://avatars3.githubusercontent.com/MatthieuMARTIN?s=600
 link: https://matthieu-martin.fr
 github: MatthieuMARTIN
 start: 2019-02-01
@@ -9,4 +8,3 @@ employer: independent
 startups:
     - competences-pro
 ---
-

--- a/content/_authors/michel.perrel.md
+++ b/content/_authors/michel.perrel.md
@@ -1,7 +1,6 @@
 ---
 fullname: Michel Perrel
 role: Intrapreneur
-avatar: https://avatars1.githubusercontent.com/u/34424209?s=400&u=ed4fc31733a5e6e3ec3cd2396701812d0c33e801&v=4
 github: michelperrel
 start: 2017-12-31
 end: 2018-06-30

--- a/content/_authors/nicolas.fournier.md
+++ b/content/_authors/nicolas.fournier.md
@@ -1,7 +1,6 @@
 ---
 fullname: Nicolas Fournier
 role: Product Owner
-avatar: https://avatars1.githubusercontent.com/u/7499866?s=460&v=4
 github: nfournier
 start: 2018-10-29
 employer: service/octo

--- a/content/_authors/nicolas.kremer.md
+++ b/content/_authors/nicolas.kremer.md
@@ -1,7 +1,6 @@
 ---
 fullname: Nicolas Kremer
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/soulso?s=600
 github: soulso
 start: 2018-12-13
 end: 2019-09-30

--- a/content/_authors/nicolas.lagreze.md
+++ b/content/_authors/nicolas.lagreze.md
@@ -1,7 +1,6 @@
 ---
 fullname: Nicolas Lagrèze
 role: Coach
-avatar: https://avatars3.githubusercontent.com/u/38190705?s=400&u=77bba6c343053aabcc7ebe3b07e2f64ca09966d4&v=4
 link: https://www.linkedin.com/in/nlagreze/
 github: nlagreze
 start: 2018-04-05

--- a/content/_authors/nicolas.merigot.md
+++ b/content/_authors/nicolas.merigot.md
@@ -2,7 +2,6 @@
 fullname: Nicolas Mérigot
 role: Développeur
 github: nmrgt
-avatar: https://avatars2.githubusercontent.com/u/17193937?s=400&v=4
 start: 2019-01-28
 end: 2019-05-31
 employer: independent/Codeurs en Liberté

--- a/content/_authors/olivier.pizzato.md
+++ b/content/_authors/olivier.pizzato.md
@@ -1,7 +1,6 @@
 ---
 fullname: Olivier Pizzato
 role: Coach
-avatar: https://avatars3.githubusercontent.com/opizzato?s=600
 github: opizzato
 start: 2018-12-17
 employer: independent/dinsic

--- a/content/_authors/philemon.perrot.md
+++ b/content/_authors/philemon.perrot.md
@@ -1,7 +1,6 @@
 ---
 fullname: Philémon Perrot
 role:  Chargé de développement
-avatar: https://avatars3.githubusercontent.com/philemon95?s=600
 github: philemon95
 start: 2019-01-14
 end: 2019-06-01

--- a/content/_authors/pierre-louis.rolle.md
+++ b/content/_authors/pierre-louis.rolle.md
@@ -1,7 +1,6 @@
 ---
 fullname: Pierre-Louis Rolle
 role: Intrapreneur
-avatar: https://avatars3.githubusercontent.com/PLrolle?s=600
 link: https://www.societenumerique.gouv.fr
 github: PLrolle
 start: 2019-03-13

--- a/content/_authors/pierre-olivier.mauguet.md
+++ b/content/_authors/pierre-olivier.mauguet.md
@@ -1,12 +1,11 @@
 ---
 fullname: Pierre-Olivier Mauguet
 role: Développeur
-avatar: https://avatars2.githubusercontent.com/u/3749428?s=460&v=4
 link: http://pom421.github.io/
 github: pom421
-start: 2019-03-11 
+start: 2019-03-11
 end: 2019-06-30
 employer: independent/octo
-startups: 
+startups:
     - signalement
 ---

--- a/content/_authors/pierre-yves.darnaudet.md
+++ b/content/_authors/pierre-yves.darnaudet.md
@@ -1,7 +1,6 @@
 ---
 fullname: Pierre-Yves Darnaudet
 role: Intrapreneur
-avatar: https://avatars3.githubusercontent.com/pydarnaudet?s=600
 github: pydarnaudet
 start: 2019-01-01
 end: 2019-06-30

--- a/content/_authors/pierre.momboisse.md
+++ b/content/_authors/pierre.momboisse.md
@@ -3,7 +3,6 @@ fullname: Pierre Momboisse
 role: Chargé de développement
 start: 2018-04-25
 end: 2018-06-30
-avatar: https://avatars3.githubusercontent.com/PMombs?s=600
 employer: independent/octo
 github: PMombs
 startups:

--- a/content/_authors/raphael.dubigny.md
+++ b/content/_authors/raphael.dubigny.md
@@ -1,7 +1,6 @@
 ---
 fullname: Raphaël Dubigny
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/rdubigny?s=600
 link: http://red-needles.com/
 github: rdubigny
 start: 2018-05-30

--- a/content/_authors/raphael.huchet.md
+++ b/content/_authors/raphael.huchet.md
@@ -1,7 +1,6 @@
 ---
 fullname: Raphaël Huchet
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/rap2hpoutre?s=600
 link: https://raph.site
 github: rap2hpoutre
 start: 2018-06-25

--- a/content/_authors/sabine.safi.md
+++ b/content/_authors/sabine.safi.md
@@ -1,10 +1,9 @@
 ---
 fullname: Sabine Safi
-role: PO / Chargée de déploiement 
-avatar: https://avatars3.githubusercontent.com/sabinesafi?s=600
+role: PO / Chargée de déploiement
 github: sabinesafi 
 start: 2019-02-04
-end: 
+end:
 employer: independent/lazone
 startups:
     - transport

--- a/content/_authors/salim.boulkour.md
+++ b/content/_authors/salim.boulkour.md
@@ -1,7 +1,6 @@
 ---
 fullname: Salim Boulkour # penser à modifier le nom du fichier ci-dessus en prenom.nom.md !
 role: Ops / DevOps
-avatar: https://avatars3.githubusercontent.com/sboulkour?s=600
 github: sboulkour
 start: 2019-01-01
 end: 2019-06-30

--- a/content/_authors/samuel.faure.md
+++ b/content/_authors/samuel.faure.md
@@ -1,7 +1,6 @@
 ---
 fullname: Samuel Faure
 role: Développeur Fullstack
-avatar: https://avatars3.githubusercontent.com/samuelfaure?s=600
 github: Samuelfaure
 start: 2017-04-24
 end: 2017-10-24

--- a/content/_authors/selim.boudaa.md
+++ b/content/_authors/selim.boudaa.md
@@ -1,9 +1,8 @@
 ---
-fullname: Sélim Boudaa # penser à modifier le nom du fichier ci-dessus en prenom.nom.md !
+fullname: Sélim Boudaa
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/SelimBoudaa?s=600
 link: http://www.sinusoide.fr
-github: SelimBoudaa # optionnel : nom d'utilisateur GitHub, permet d'être ajouté automatiquement à l'organisation GitHub betagouv
+github: SelimBoudaa
 start: 2018-10-05
 end: 2018-11-30
 employer: independent/octo

--- a/content/_authors/simon.pineau.md
+++ b/content/_authors/simon.pineau.md
@@ -1,9 +1,9 @@
 ---
 fullname: Simon Pineau
 role: Chargé de développement
-avatar: https://avatars3.githubusercontent.com/simonpineau?s=600
 github: simonpineau
 start: 2018-07-11
+end: 2018-11-30
 employer: independent/informatique convivial
 startups:
     - aplus

--- a/content/_authors/stephane.hanser.md
+++ b/content/_authors/stephane.hanser.md
@@ -1,7 +1,6 @@
 ---
 fullname: Stéphane Hanser
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/shanser?s=600
 link: https://captive.fr
 github: shanser
 start: 2019-02-25

--- a/content/_authors/stephane.legouffe.md
+++ b/content/_authors/stephane.legouffe.md
@@ -1,7 +1,6 @@
 ---
 fullname: Stéphane Legouffe
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/slegouffe?s=600
 link: https://wawy.io
 github: slegouffe
 start: 2018-03-08

--- a/content/_authors/thibault.jouannic.md
+++ b/content/_authors/thibault.jouannic.md
@@ -1,7 +1,6 @@
 ---
 fullname: Thibault Jouannic
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/thibault?s=600
 link: https://www.miximum.fr
 github: thibault
 start: 2018-08-01

--- a/content/_authors/thibaut.sailly.md
+++ b/content/_authors/thibaut.sailly.md
@@ -1,7 +1,6 @@
 ---
 fullname: Thibaut Sailly
 role: Designer
-avatar: https://avatars3.githubusercontent.com/thibautsailly?s=600
 link: https://tsailly.net
 github: thibautsailly
 start: 2019-02-01

--- a/content/_authors/thomas.bouchardon.md
+++ b/content/_authors/thomas.bouchardon.md
@@ -1,7 +1,6 @@
 ---
 fullname: Thomas Bouchardon
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/alfabouch?s=600
 github: alfabouch
 start: 2018-11-09
 end:

--- a/content/_authors/thomas.parisot.md
+++ b/content/_authors/thomas.parisot.md
@@ -4,7 +4,6 @@ role: Software Designer
 start: 2017-06-14
 end: 2017-12-30
 employer: independent/octo
-avatar: https://avatars.githubusercontent.com/u/138627?v=3&s=600
 link: https://oncletom.io
 github: oncletom
 startups:

--- a/content/_authors/thomas.pepio.md
+++ b/content/_authors/thomas.pepio.md
@@ -1,7 +1,6 @@
 ---
 fullname: Thomas Pepio
 role: DevOps
-avatar: https://avatars1.githubusercontent.com/u/6214327?v=3&u=850d498eb3c255c6ea3bdc630db7ea93628fcee6&s=400
 start: 2017-07-11
 end: 2017-10-30
 employer: service/octo

--- a/content/_authors/tristan.robert.md
+++ b/content/_authors/tristan.robert.md
@@ -1,7 +1,6 @@
 ---
-fullname: Tristan Robert 
+fullname: Tristan Robert
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/u/19711088?s=460&v=4
 github: tristanrobert
 start: 2018-11-19
 employer: admin/MTES-MCT

--- a/content/_authors/tristram.grabener.md
+++ b/content/_authors/tristram.grabener.md
@@ -1,7 +1,6 @@
 ---
 fullname: Tristram Gräbener
 role: Développeur
-avatar: https://avatars2.githubusercontent.com/u/12235
 github: Tristramg
 start: 2018-03-01
 end: 2020-02-28

--- a/content/_authors/yann.boisselier.md
+++ b/content/_authors/yann.boisselier.md
@@ -1,7 +1,6 @@
 ---
 fullname: Yann Boisselier
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/nyl-auster?s=600
 link: https://www.happy-dev-nantes.fr/
 github: nyl-auster
 start: 2018-03-06

--- a/content/_authors/yannick.francois.md
+++ b/content/_authors/yannick.francois.md
@@ -1,7 +1,6 @@
 ---
 fullname: Yannick François
 role: Développeur
-avatar: https://avatars3.githubusercontent.com/u/42057?s=460&v=4
 link: https://elsif.fr
 github: yaf
 start: 2018-12-12

--- a/content/templates/authors.md
+++ b/content/templates/authors.md
@@ -1,15 +1,15 @@
 ---
 fullname: Camille Dupont # penser à modifier le nom du fichier ci-dessus en prenom.nom.md !
 role: Smartass # Développeu·r·se / Intrapreneu·r·se / Coach / Chargé de développement / ...
-# ci-dessous, remplace pseudo_github par ton propre pseudo Github pour utiliser la photo de ton profil
-# tu peux aussi fournir l'URL (HTTPS obligatoire) d'une image carrée 512x512 minimum
-# à défaut, si tu laisses ce champs vide, alors ton avatar sera l'image prenom.nom du dossier /img/authors/
-# si aucune image n'est trouvée, alors la fiole beta.gouv.fr sera utilisée sur le site
-avatar: https://avatars3.githubusercontent.com/pseudo_github?s=600
-link: # optionnel : lien vers une page perso externe. Effacer cette ligne si rien à mettre.
 github: pseudo_github # optionnel : nom d'utilisateur GitHub, permet d'être ajouté automatiquement à l'organisation GitHub betagouv
-start: 2016-12-31 # date d'arrivée au format ISO (AAAA-MM-JJ)
-end: 2017-09-15 # date de fin de contrat au format ISO (AAAA-MM-JJ)
+avatar: # optionnel, voir ci-dessous
+# En premier, on va regarder si tu as mis une image au format prenom.nom dans /img/authors/
+# Sinon, on utilisera le lien externe du champs avatar
+# Si tu laisse ce champs vide, alors on regardera si tu as une image sur GitHub
+# Enfin, si aucune image n'est trouvée, alors la fiole beta.gouv.fr sera utilisée sur la page communauté
+link: # optionnel : lien vers une page perso externe.
+start: 2019-01-01 # date d'arrivée au format ISO (AAAA-MM-JJ)
+end: 2019-12-31 # date de fin de contrat au format ISO (AAAA-MM-JJ)
 employer: # dinsic ou independent/<employer> ou admin/<employer> ou service/octo
 startups: # ta ou tes startups actuelles
     - super_startup # le nom du fichier de la startup dans le répertoire /content/_startups/ sans l'extension .md


### PR DESCRIPTION
Cette PR modifie la règle d'affichage des avatars des membres. Dans les faits, la plupart utilisent déjà l'image de github et ont renseigné leur pseudo github. Alors, une règle supplémentaire est ajoutée afin de ne pas avoir à remplir la ligne avatar.

La logique du choix de l'avatar est maintenant (cf _includes/avatar.html)
- présence d'une image dans le dossier /img/authors
- présence d'un lien externe
- (new!) image du compte github
- image de la fiole si le paramètre de forçage est passé

J'ai modifié les fiches des membres en conséquence parce que je devais tester pour vérifier si rien n'était cassé. J'ai supprimé le lien externe qui pointait déjà vers Github pour tous les membres qui ont renseigné leur compte github.

J'ai également modifié le template en conséquence.