### PR TITLE
Fix mobilot -> lotocar

### DIFF
--- a/content/_authors/anne-laure.guillerme.md
+++ b/content/_authors/anne-laure.guillerme.md
@@ -5,5 +5,5 @@ start: 2018-11-19
 end: 2019-05-31
 employer: admin
 startups:
-    - mobilot
+    - lotocar
 ---

--- a/content/_authors/cherif.mili.md
+++ b/content/_authors/cherif.mili.md
@@ -5,5 +5,5 @@ start: 2018-11-19
 end: 2019-05-31
 employer: independent
 startups:
-    - mobilot
+    - lotocar
 ---

--- a/content/_authors/francois-joseph.grimault.md
+++ b/content/_authors/francois-joseph.grimault.md
@@ -7,7 +7,7 @@ end: 2019-05-31
 employer: independent
 github: fjg
 startups:
-    - mobilot
+    - lotocar
     - mrs
 ---
 

--- a/content/_startups/lotocar.md
+++ b/content/_startups/lotocar.md
@@ -10,6 +10,8 @@ link: https://www.lotocar.fr
 repository:
 stats: false
 contact: contact@mobilot.beta.gouv.fr
+redirect_from:
+  - /startups/mobilot
 ---
 
 ## Le constat


### PR DESCRIPTION
Corrige le renommage de mobilot en lotocar sur les fiches des membres et ajoute un redirect_from pour faire plus propre.