### PR TITLE
Remove temporary banner on the jobs page for the 1st Tech Meetup

### DIFF
--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -5,9 +5,6 @@ layout: default
 {% assign lang = page.lang | default: site.lang | default: "fr" %}
 <div class="page article">
   {% include hero-page.html title=page.title %}
-  <div class="notification full-width">
-    Les développeurs de beta.gouv.fr organisent leur premier <a href="https://www.eventbrite.fr/e/billets-meetup-tech-betagouvfr-x-latitudes-59297040043">Meetup Tech</a> le 11 avril à Paris en partenariat avec Latitudes. C'est ouvert à tous, n'hésitez pas à venir discuter avec nous !
-  </div>
   <section class="section section-white cards">
     <div class="container jobs">
       <h3>Offres disponibles</h3>


### PR DESCRIPTION
Le meetup est passé, on enlève la bannière de la page recrutement.

This reverts commit 1ed094de0c67ec373dcc39adf3eea48929dafb55.
