### PR TITLE
Clarification titre de l'offre d'emploi

### DIFF
--- a/content/_jobs/2019-04-23-aidantsconnect-designer.md
+++ b/content/_jobs/2019-04-23-aidantsconnect-designer.md
@@ -1,5 +1,5 @@
 ---
-roles: une personne chargée de la recherche utilisateurs
+roles: une ou un designer en charge de la recherche utilisateurs
 startup: aidantsconnect
 open: true
 ---


### PR DESCRIPTION
Les retours sur l'offre sont qu'il manque vraiment le mot designer.