### PR TITLE
Retour au bleu dans le template

### DIFF
--- a/_sass/hacks.scss
+++ b/_sass/hacks.scss
@@ -249,8 +249,8 @@ header.navbar {
 }
 
 .hero.article__hero {
-    background-color: #fff;
-    color: #000;
+    background-color: #0053b3;
+    color: #fff;
     padding: 4em 0;
 }
 


### PR DESCRIPTION
Le bleu permettait une séparation nette qui, il me semble, structurait nos pages.
Le fond blanc a pour conséquence de faire "flotter" le titre des pages.
