### PR TITLE
Supprime `base_url` et utilise l'authentification Github via Netlify directement

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,6 +1,5 @@
 backend:
   name: github
-  base_url: https://api.staticweb-01.etalab.gouv.fr
   site_domain: beta.gouv.fr
   repo: betagouv/beta.gouv.fr
   # Personnalisation des messages de commit


### PR DESCRIPTION
Le serveur `staticweb-01.etalab.gouv.fr` n'est pas vraiment maintenu chez nous et cette configuration ne parait pas nécessaire (mais je peux me tromper) car Netlify est capable de gérer l'authentification Github sur ses propres serveurs.

Avec un peu de chance on pourra tester tout ça depuis cette PR. Il y a peut-être un peu de conf à faire quand même https://www.netlify.com/docs/authentication-providers/#using-an-authentication-provider ?

https://www.netlifycms.org/docs/authentication-backends/#github-backend

https://github.com/netlify/netlify-cms/issues/663#issuecomment-335023723

> This means that there needs to be a server-side component to any application that wants to talk to GitHub's API through OAuth. And **Netlify offers such a server-side component**, and I also have the option of running one myself