### PR TITLE
Mise à jour Thomas Menant

### DIFF
--- a/content/_authors/thomas.menant.md
+++ b/content/_authors/thomas.menant.md
@@ -1,6 +1,6 @@
 ---
 fullname: Thomas Menant
-role: Expertise juridique
+role: Claquettiste 🕺
 missions:
   - start: '2014-01-01'
     end: '2019-12-31'


### PR DESCRIPTION
Passage de expert juridique à claquettiste.

En effet, l'utilisation du terme juridique n'est pas conseillée.
