### PR TITLE
Redirige /postuler vers contact

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -19,4 +19,4 @@
 
 # Redirection de l'ancienne page de recrutement
 
-/postuler/ /recrutement/
+/postuler/ /contact/

--- a/_redirects
+++ b/_redirects
@@ -16,3 +16,7 @@
 # Gérer les liens vers les anciens documents
 /rapportannuel.pdf /content/docs/rapportannuel.pdf
 /guide.pdf /content/docs/guide.pdf
+
+# Redirection de l'ancienne page de recrutement
+
+/postuler/ /recrutement/

--- a/postuler.html
+++ b/postuler.html
@@ -1,5 +1,0 @@
----
-permalink: /postuler
-redirect_to:
-  - contact
----

--- a/postuler.html
+++ b/postuler.html
@@ -1,5 +1,5 @@
 ---
 permalink: /postuler
 redirect_to:
-  - https://betagouvfr.recruitee.com/o/tu-veux-rejoindre-une-startup-detat-ecrisnous/c/new
+  - contact
 ---


### PR DESCRIPTION
L'abonnement Recrutee est annulé.
On peut mettre la page de beta.gouv.fr/recrutement aussi 