### PR TITLE
Corrige le formatage markdown pour Laurene Houtin

### DIFF
--- a/content/_authors/laurene.houtin.md
+++ b/content/_authors/laurene.houtin.md
@@ -1,13 +1,15 @@
+---
 fullname: Laurene Houtin
 role: Experte scientifique
 github: laurenehoutin
 link: https://www.ad-hoc-lab.com
-missions: # ton historique de missions avec nous dans l'ordre chronologique. Remplis déjà la première pour commencer !
- - start: '2019-09-26' # date d'arrivée au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
-   end: '2019-12-31' # date de fin de contrat au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
-   status: service
-   employer: AD-HOC Lab # si applicable, le nom de ton administration, SSII, etc.
+missions:
+  - start: '2019-09-26'
+    end: '2019-12-31'
+    status: service
+    employer: AD-HOC Lab
 startups: 
-   - competences-pro
+  - competences-pro
 ---
+
 Réfutabilité/Méthode/Ethique 


### PR DESCRIPTION
Il manquait la première ligne de tiret.

J'en ai profité pour supprimer les commentaires et soigner les indentations
