### PR TITLE
précise le renommage de la startup dans le titre de eva

### DIFF
--- a/content/_startups/eva.md
+++ b/content/_startups/eva.md
@@ -1,5 +1,5 @@
 ---
-title: eva
+title: eva (anciennement Compétences pro)
 mission: Favoriser l’insertion en détectant les compétences transversales et valorisant les potentiels à travers un outil de mise en situation numérique
 
 owner: Haut-commissaire aux compétences et à l’inclusion par l’emploi - DGEFP


### PR DESCRIPTION
Renomme le titre de eva pour rendre explicite que c'est le nouveau nom de la startup `Compétences pro`

![Capture d’écran 2019-12-11 à 12 07 23](https://user-images.githubusercontent.com/28393/70617006-f349ab00-1c0f-11ea-9af7-419587fb97d0.png)
![Capture d’écran 2019-12-11 à 12 07 35](https://user-images.githubusercontent.com/28393/70617007-f349ab00-1c0f-11ea-97a5-acb3e0981a53.png)


fix competences-pro#647
