### PR TITLE
Ajoute le programme de préincubation comme incubateur

### DIFF
--- a/content/_incubators/preincubation.md
+++ b/content/_incubators/preincubation.md
@@ -1,0 +1,10 @@
+---
+title: Programme de préincubation
+owner: DINUM
+website: https://beta.gouv.fr/preincubation/
+github: https://github.com/betagouv/
+contact: mailto:contact@beta.gouv.fr?subject=Préincubation
+address: 20 avenue de Ségur, Paris 15è
+---
+
+Le programme de préinubation est dérit plus en détail[ici](https://beta.gouv.fr/preincubation/).

--- a/content/_startups/onstage.md
+++ b/content/_startups/onstage.md
@@ -2,7 +2,7 @@
 title: OnStage
 mission: Renforcer les liens entre jeunes citoyens et entreprises du departement
 owner: Département des Côtes d'Armor
-incubator: dinsic 
+incubator: preincubation
 status: investigation
 start: 2019-01-12
 end: 

--- a/content/_startups/protege-toit.md
+++ b/content/_startups/protege-toit.md
@@ -2,7 +2,7 @@
 title: Protège-Toit 🏡
 mission: Améliorer la prise en charge d'urgence pour les victimes de violences conjugales
 owner: Département des Côtes d'Armor
-incubator: dinsic 
+incubator: preincubation
 status: investigation
 start: 2019-01-12
 end: 

--- a/content/_startups/rest-0.md
+++ b/content/_startups/rest-0.md
@@ -2,7 +2,7 @@
 title: Rest'0
 mission: Réduire le gaspillage alimentaire dans les cantines scolaires
 owner: Département des Côtes d'Armor
-incubator: dinsic 
+incubator: preincubation
 status: investigation
 start: 2019-01-12
 end: 


### PR DESCRIPTION
La finalité de cette PR est de permettre au programme de préincubation d'apparaître lors du [standup](https://github.com/betagouv/standup).

C'est un contournement temporaire, le programme ne remplit pas les critères d'un incubateur, la modélisation du site beta.gouv.fr est appelée à évoluer pour tenir compte de nouvelles réalités.

A terme, il me semble qu'il faudrait faire converger les sujets de préincubation (dans `content/_seedlings`) avec les autres fiches produit.