### PR TITLE
Mise à jour de date de fin

### DIFF
--- a/content/_authors/jonathan.fallon.md
+++ b/content/_authors/jonathan.fallon.md
@@ -4,7 +4,7 @@ role: Développeur
 github: jonathanfallon
 missions:
   - start: '2018-11-05'
-    end: '2020-02-28'
+    end: '2020-07-31'
     status: independent
     employer: Codeurs en Liberté
 startups:


### PR DESCRIPTION
Post comité de refinancement, la startup Registre de preuve de covoiturage est prolongée au moins jusque juillet 2020 ! :champagne: 