### PR TITLE
DINSIC -> DINUM

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Le site public de l'Incubateur de Services Numériques de l'État français.
 Ce nom de domaine héberge :
 
 - Une présentation de la méthode Startup d'État et valorisation de ses produits.
-- Une présentation de chaque incubateur de la communauté `beta.gouv.fr` dont l'Incubateur de Services Numériques de la DINSIC, initiateur de la méthode.
+- Une présentation de chaque incubateur de la communauté `beta.gouv.fr` dont l'Incubateur de Services Numériques de la DINUM, initiateur de la méthode.
 - Les membres actifs et anciens des incubateurs
 - Les offres de recrutement de la communauté
 

--- a/_includes/sidebar-incubateurs.html
+++ b/_includes/sidebar-incubateurs.html
@@ -6,7 +6,7 @@
       <a class="side-pane__link" href="/incubateurs">Le manifeste</a>
     </li>
     <li class="side-pane__dropdown unfolded">
-      <a href="/incubateurs/dinsic.html">Les incubateurs</a>
+      <a href="/incubateurs/dinum.html">Les incubateurs</a>
       <ul class="side-pane__submenu">
           {% for incubator in incubators %}
           <li {% if page.id == incubator.id %}class="active"{% endif %}>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -48,7 +48,7 @@ Toutes les Startups d'État présentent publiquement des mesures d’impact auto
 
 * **_de réduire les coûts administratifs_** dans plus de 20 organismes publics en diminuant le temps de traitement des dossiers de 50 % : [demarches-simplifiees.fr](https://www.demarches-simplifiees.fr/).
 
-Elles exercent aussi un effet d’entraînement sur la modernisation des administrations. Au sein de Pôle Emploi, qui a noué dès 2015 un partenariat avec la DINSIC (Ancien nom de l'actuelle DINUM) et investit aujourd’hui annuellement près de 6 M€ dans les Startups d'État, les équipes, composées à l’origine essentiellement de freelances, accueillent aujourd’hui des talents issus de la DSI ou des agences, permettant ainsi une diversification des carrières et une réaffectation des agents publics sur des missions à plus fort impact.
+Elles exercent aussi un effet d’entraînement sur la modernisation des administrations. Au sein de Pôle Emploi, qui a noué dès 2015 un partenariat avec la DINSIC (ancien nom de l'actuelle DINUM) et investit aujourd’hui annuellement près de 6 M€ dans les Startups d'État, les équipes, composées à l’origine essentiellement de freelances, accueillent aujourd’hui des talents issus de la DSI ou des agences, permettant ainsi une diversification des carrières et une réaffectation des agents publics sur des missions à plus fort impact.
 
 ### Plus d’infos ?
 

--- a/_pages/en/about.md
+++ b/_pages/en/about.md
@@ -6,7 +6,7 @@ title: About us
 
 ## Background
 
-**beta.gouv.fr** is the Digital Services Incubator, a mission of the French government’s [DINSIC - FR](https://numerique.gouv.fr/). Our aim is to spread the culture of digital innovation throughout the administration. We do this through State Startups.
+**beta.gouv.fr** is the Digital Services Incubator, a mission of the French government’s [DINUM - FR](https://numerique.gouv.fr/). Our aim is to spread the culture of digital innovation throughout the administration. We do this through State Startups.
 
 A State Startup is not just an oxymoron, but a match between a team and a mission. There is no capital investment, no separate juridical entity, only the usage of the tools and practices of the digital startups to solve a friction in an interaction an administration has with citizens. We help it identify an “intrapreneur”, one of its civil servants ready to hustle her way into delivering a digital public service, and create a team of experts around her. We hire developers, data scientists, designers, product managers and all needed talents, either under short-term contracts or as independent contractors, and coach that team so it stays laser-focused on solving real-world issues for real-world users. This team of 2 to 4 people will have 6 months to prove a digital product can improve the situation.
 

--- a/_pages/preincubation/presentation.md
+++ b/_pages/preincubation/presentation.md
@@ -12,7 +12,7 @@ D'une durée de trois mois, ce programme vise à faire émerger des projets d’
 
 L’objectif du programme est de préciser l’ampleur du problème visé et de présenter des premiers éléments de solution pour le résoudre.
 
-Le partenaire apporte des projets d’innovation, des agents pour les porter et un financement pour l’accompagnement. La DINSIC apporte un appui opérationnel.
+Le partenaire apporte des projets d’innovation, des agents pour les porter et un financement pour l’accompagnement. La DINUM apporte un appui opérationnel.
 
 Les phases du programme de préincubation sont les suivantes :
 1. Validation de la sélection en accord avec les projets identifiés ;

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -79,7 +79,7 @@ collections:
             name: "status"
             widget: "select"
             options:
-              - { label: "Agent DINSIC", value: "dinsic" }
+              - { label: "Agent DINUM", value: "dinum" }
               - { label: "Agent d'une autre administration", value: "admin" }
               - { label: "Indépendant", value: "independent" }
               - { label: "Société ou prestataire de services", value: "service" }

--- a/content/_authors/agathe.le_nahenec.md
+++ b/content/_authors/agathe.le_nahenec.md
@@ -4,6 +4,7 @@ role: Responsable de produit
 missions:
   - start: '2015-06-01'
     end: '2016-01-31'
+    employer: dinum
     status: admin
 startups:
 previously:

--- a/content/_authors/alexandre.segura.md
+++ b/content/_authors/alexandre.segura.md
@@ -5,9 +5,11 @@ avatar: 'https://avatars2.githubusercontent.com/alexsegura?s=600'
 missions:
   - end: '2019-05-14'
     start: '2018-05-14'
+    employer: dinum
     status: admin
   - end: '2019-10-17'
     start: '2019-06-17'
+    employer: dinum
     status: admin
 startups:
   - mes-aides

--- a/content/_authors/amandine.audras.md
+++ b/content/_authors/amandine.audras.md
@@ -4,10 +4,10 @@ role: UX Designer
 github: renardpal
 link: ''
 missions:
-  - employer: dinsic
-    start: '2018-11-02'
+  - start: '2018-11-02'
     end: '2019-06-30'
     status: admin
+    employer: dinum
   - start: '2019-09-02'
     end: '2020-06-30'
     status: independent

--- a/content/_authors/anne-sophie.tranchet.md
+++ b/content/_authors/anne-sophie.tranchet.md
@@ -11,7 +11,7 @@ link: https://hello-bokeh.fr/ # optionnel : lien vers une page perso externe.
 missions: # ton historique de missions avec nous dans l'ordre chronologique. Remplis déjà la première pour commencer !
   - start: '2020-03-17' # date d'arrivée au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
     end: '2020-09-17' # date de fin de contrat au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
-    status: independent # dinsic (pour agent DINSIC) ou independent (pour indépendant) ou admin (pour agent d'une autre administration) ou service (pour société de service)
+    status: independent
     employer: Octo # si applicable, le nom de ton administration, SSII, etc.
 #startups: # ta ou tes startups actuelles
 #    - super_startup # le nom du fichier de la startup dans le répertoire /content/_startups/ sans l'extension .md

--- a/content/_authors/antoine.martin.md
+++ b/content/_authors/antoine.martin.md
@@ -4,6 +4,7 @@ role: Chargé de déploiement
 missions:
   - start: '2019-09-11'
     end: '2020-01-24'
+    employer: dinum
     status: admin
 github: antoine-martin-ponts
 startups:

--- a/content/_authors/antoine.michon.md
+++ b/content/_authors/antoine.michon.md
@@ -5,5 +5,5 @@ github: antoinemch
 missions:
   - start: '2019-09-02'
     status: admin
-    employer: DINUM
+    employer: dinum
 ---

--- a/content/_authors/antonin.garrone.md
+++ b/content/_authors/antonin.garrone.md
@@ -6,6 +6,7 @@ link: https://www.linkedin.com/in/antonin-garrone-8272bb154/
 missions:
   - start: '2019-01-14'
     end: '2019-07-13'
+    employer: dinum
     status: admin
 startups:
 ---

--- a/content/_authors/arnaud.denoix.md
+++ b/content/_authors/arnaud.denoix.md
@@ -5,6 +5,7 @@ github: adenoix
 missions:
   - start: '2018-12-07'
     end:
+    employer: dinum
     status: admin
 startups:
   - itou

--- a/content/_authors/augustin.wenger.md
+++ b/content/_authors/augustin.wenger.md
@@ -6,6 +6,7 @@ github: magemax
 missions:
   - start: '2019-01-21'
     end: '2020-01-03'
+    employer: dinum
     status: admin
 startups:
   - leximpact

--- a/content/_authors/beatrice.mercier.md
+++ b/content/_authors/beatrice.mercier.md
@@ -9,7 +9,7 @@ missions:
   - start: '2019-05-13'
     end: '2020-05-13'
     status: admin
-    employer: DINSIC
+    employer: dinum
 startups:
     - transport
 ---

--- a/content/_authors/benjamin.henkel.md
+++ b/content/_authors/benjamin.henkel.md
@@ -4,6 +4,7 @@ role: Chargé de développement
 missions:
   - start: '2017-06-01'
     end: '2017-10-30'
+    employer: dinum
     status: admin
   - start: '2019-05-17'
     end: '2020-01-31'

--- a/content/_authors/charlotte.lecuit.md
+++ b/content/_authors/charlotte.lecuit.md
@@ -4,6 +4,7 @@ role: Chargée de déploiement
 missions:
   - start: '2018-05-14'
     end: '2019-06-30'
+    employer: dinum
     status: admin
 startups:
     - mes-aides

--- a/content/_authors/christian.quest.md
+++ b/content/_authors/christian.quest.md
@@ -4,6 +4,7 @@ role: Datatouilleur
 missions:
   - start: '2014-09-01'
     end: '2019-03-15'
+    employer: dinum
     status: admin
   - start: '2019-05-01'
     status: independent

--- a/content/_authors/dorine.lambinet.md
+++ b/content/_authors/dorine.lambinet.md
@@ -5,6 +5,7 @@ github: DorineLam
 missions:
   - start: '2019-01-21'
     end: '2020-10-20'
+    employer: dinum
     status: admin
 startups:
   - leximpact

--- a/content/_authors/elise.levy.md
+++ b/content/_authors/elise.levy.md
@@ -4,6 +4,7 @@ role: Responsable de produit junior
 missions:
   - start: '2017-03-06'
     end: '2017-09-06'
+    employer: dinum
     status: admin
 startups:
 previously:

--- a/content/_authors/etienne.puydebois.md
+++ b/content/_authors/etienne.puydebois.md
@@ -5,6 +5,7 @@ avatar: https://avatars3.githubusercontent.com/rosedeschamps?s=600
 missions:
   - start: '2017-09-04'
     end: '2018-03-02'
+    employer: dinum
     status: admin
 startups:
 previously:

--- a/content/_authors/fanny.brulebois.md
+++ b/content/_authors/fanny.brulebois.md
@@ -4,6 +4,7 @@ role: Responsable de produit
 missions:
   - start: '2016-02-15'
     end: '2016-07-01'
+    employer: dinum
     status: admin
 startups:
 previously:

--- a/content/_authors/florian.delezenne.md
+++ b/content/_authors/florian.delezenne.md
@@ -9,6 +9,7 @@ missions:
     status: service
   - start: '2017-06-01'
     end: '2021-02-15'
+    employer: dinum
     status: admin
 startups:
   - api-particulier

--- a/content/_authors/florian.pagnoux.md
+++ b/content/_authors/florian.pagnoux.md
@@ -4,6 +4,7 @@ role: Développeur
 missions:
   - start: '2015-04-30'
     end: '2017-10-26'
+    employer: dinum
     status: admin
 startups:
 previously:

--- a/content/_authors/georges.bayard.md
+++ b/content/_authors/georges.bayard.md
@@ -4,6 +4,7 @@ role: Responsable de produit
 missions:
   - start: '2016-03-01'
     end:
+    employer: dinum
     status: admin
 startups:
   - mps

--- a/content/_authors/guillaume.harry.md
+++ b/content/_authors/guillaume.harry.md
@@ -5,6 +5,7 @@ link: https://www.linkedin.com/in/guillaume-harry-32885637/
 missions:
   - start: '2017-10-18'
     end: '2018-06-20'
+    employer: dinum
     status: admin
 ---
 

--- a/content/_authors/hela.ghariani.md
+++ b/content/_authors/hela.ghariani.md
@@ -4,6 +4,7 @@ role: Responsable de produit
 missions:
   - start: '2014-11-01'
     end: '2019-10-30'
+    employer: dinum
     status: admin
 startups:
   - mdph

--- a/content/_authors/ishan.bhojwani.md
+++ b/content/_authors/ishan.bhojwani.md
@@ -4,12 +4,14 @@ role: Coach
 missions:
   - start: '2017-05-23'
     end: '2017-08-31'
+    employer: dinum
     status: admin
   - start: '2017-09-01'
     end: '2018-12-31'
     status: independent
   - start: '2019-01-01'
     end: '2021-12-31'
+    employer: dinum
     status: admin
 github: IshanB
 startups:

--- a/content/_authors/jeremie.cook.md
+++ b/content/_authors/jeremie.cook.md
@@ -6,6 +6,7 @@ link: https://jeremiecook.com
 missions:
   - start: '2018-07-10'
     end: '2019-07-01'
+    employer: dinum
     status: admin
   - start: '2019-07-02'
     end: '2019-12-31'    

--- a/content/_authors/jerome.desboeufs.md
+++ b/content/_authors/jerome.desboeufs.md
@@ -3,15 +3,15 @@ fullname: Jérôme Desboeufs
 role: Développeur
 github: jdesboeufs
 missions:
-  - employer: ''
-    end: '2015-03-09'
+  - end: '2015-03-09'
     start: '2014-03-10'
+    employer: dinum
     status: admin
   - employer: Octo
     end: '2015-09-09'
     start: '2015-03-10'
     status: service
-  - employer: Living Data
+  - employer: 'Living Data'
     end:
     start: '2015-09-18'
     status: independent

--- a/content/_authors/jihane.herizi.md
+++ b/content/_authors/jihane.herizi.md
@@ -2,11 +2,12 @@
 fullname: Jihane Herizi
 role: Co-animatrice du programme Startups d'État
 missions:	
-  - start: '2017-10-11'	 
-    end: '2019-12-31'	    
+  - start: '2017-10-11'
+    end: '2019-12-31'
     status: independent
   - start: '2020-01-05'
     end: '2023-01-05'
+    employer: dinum
     status: admin
 previously:
   - pass-culture

--- a/content/_authors/julien.dauphant.md
+++ b/content/_authors/julien.dauphant.md
@@ -7,9 +7,10 @@ missions:
     start: '2016-11-03'
     end: '2019-08-31'
     status: independent
-  - status: admin
-    start: '2019-09-01'
+  - start: '2019-09-01'
     end: '2022-08-31'
+    status: admin
+    employer: dinum
 startups:
   - plante-et-moi
   - aplus

--- a/content/_authors/kara.diaby.md
+++ b/content/_authors/kara.diaby.md
@@ -5,7 +5,7 @@ github: kara22
 missions: 
   - start: '2020-02-03' # date d'arrivée au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
     end: '2020-06-03' # date de fin de contrat au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
-    status: independent # dinsic (pour agent DINSIC) ou independent (pour indépendant) ou admin (pour agent d'une autre administration) ou service (pour société de service)
+    status: independent
 startups:
     - DS
 ---

--- a/content/_authors/laurent.bossavit.md
+++ b/content/_authors/laurent.bossavit.md
@@ -3,11 +3,9 @@ fullname: Laurent Bossavit
 role: Coach
 missions:
   - start: '2016-03-01'
-    end: '2019-12-04'
-    status: admin
-  - start: '2019-12-06'
     end: '2021-04-05'
     status: admin
+    employer: dinum
 startups:
     - aidantsconnect
 previously:

--- a/content/_authors/loic.delmaire.md
+++ b/content/_authors/loic.delmaire.md
@@ -5,6 +5,7 @@ missions:
   - start: '2013-12-01'
     end: '2014-05-31'
     status: admin
+    employer: dinum
 startups:
 previously:
   - mps

--- a/content/_authors/louis.moscarola.md
+++ b/content/_authors/louis.moscarola.md
@@ -7,6 +7,7 @@ missions:
   - start: '2019-01-28'
     end: '2019-06-01'
     status: admin
+    employer: dinum
 startups:
  - aplus
 

--- a/content/_authors/mael.thomas.md
+++ b/content/_authors/mael.thomas.md
@@ -6,6 +6,7 @@ missions:
   - start: '2015-10-01'
     end: '2017-10-01'
     status: admin
+    employer: dinum
   - start: '2017-10-02'
     end: '2020-12-31'
     status: independent

--- a/content/_authors/margot.demaulmont.md
+++ b/content/_authors/margot.demaulmont.md
@@ -6,6 +6,7 @@ missions:
   - start: '2017-07-10'
     end: '2017-08-18'
     status: admin
+    employer: dinum
 startups:
 previously:
   - open-academie

--- a/content/_authors/marielle.variette.md
+++ b/content/_authors/marielle.variette.md
@@ -5,5 +5,6 @@ missions:
   - start: '2019-01-01'
     end: '2022-01-01'
     status: admin
+    employer: dinum
 startups:
 ---

--- a/content/_authors/martin.rueda.md
+++ b/content/_authors/martin.rueda.md
@@ -6,6 +6,7 @@ missions:
   - start: '2019-06-03'
     end: '2019-08-03'
     status: admin
+    employer: dinum
 startups:
     - transport
 ---

--- a/content/_authors/matti.schneider.md
+++ b/content/_authors/matti.schneider.md
@@ -7,6 +7,7 @@ missions:
   - start: '2014-10-01'
     end: '2017-08-31'
     status: admin
+    employer: dinum
   - start: '2019-01-10'
     end: '2019-02-28'
     status: independent

--- a/content/_authors/mauko.quiroga.md
+++ b/content/_authors/mauko.quiroga.md
@@ -6,6 +6,7 @@ missions:
   - start: '2016-02-15'
     end: '2021-03-04'
     status: admin
+    employer: dinum
 startups:
   - aplus
   - leximpact

--- a/content/_authors/michel.blancard.md
+++ b/content/_authors/michel.blancard.md
@@ -6,6 +6,7 @@ missions:
   - start: '2016-12-30'
     end: '2017-10-06'
     status: admin
+    employer: dinum
   - start: '2019-04-01'
     status: independent
     employer: Ministère des affaires étrangères

--- a/content/_authors/ndriana.razafitrimo.md
+++ b/content/_authors/ndriana.razafitrimo.md
@@ -5,6 +5,7 @@ missions:
   - start: '2019-11-04'
     end: '2020-05-03'
     status: admin
+    employer: dinum
 startups:
   - demarches-simplifiees.fr
 ---

--- a/content/_authors/nelson.perdriau.md
+++ b/content/_authors/nelson.perdriau.md
@@ -11,7 +11,7 @@ link: # optionnel : lien vers une page perso externe.
 missions: # ton historique de missions avec nous dans l'ordre chronologique. Remplis déjà la première pour commencer !
   - start: '2020-03-02' # date d'arrivée au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
     end: '2020-08-15' # date de fin de contrat au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
-    status: independent # dinsic (pour agent DINSIC) ou independent (pour indépendant) ou admin (pour agent d'une autre administration) ou service (pour société de service)
+    status: independent
     employer: codeur en liberté # si applicable, le nom de ton administration, SSII, etc.
 startups:  # ta ou tes startups actuelles
     - transport # le nom du fichier de la startup dans le répertoire /content/_startups/ sans l'extension .md

--- a/content/_authors/philemon.perrot.md
+++ b/content/_authors/philemon.perrot.md
@@ -6,6 +6,7 @@ missions:
   - start: '2019-01-14'
     end: '2019-06-01'
     status: admin
+    employer: dinum
 startups:
   - demarches-simplifiees.fr
 ---

--- a/content/_authors/philippe.vrignaud.md
+++ b/content/_authors/philippe.vrignaud.md
@@ -5,6 +5,7 @@ missions:
   - start: '2014-01-01'
     end:
     status: admin
+    employer: dinum
 startups:
     - mps
     - api-entreprise

--- a/content/_authors/raphael.odini.md
+++ b/content/_authors/raphael.odini.md
@@ -11,7 +11,7 @@ link: https://raphodn.github.io
 missions: # ton historique de missions avec nous dans l'ordre chronologique. Remplis déjà la première pour commencer !
   - start: '2020-01-08' # date d'arrivée au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
     end: '2020-06-07' # date de fin de contrat au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
-    status: independent # dinsic (pour agent DINSIC) ou independent (pour indépendant) ou admin (pour agent d'une autre administration) ou service (pour société de service)
+    status: independent
     employer: octo # si applicable, le nom de ton administration, SSII, etc.
 startups: # ta ou tes startups actuelles
     - aidantsconnect

--- a/content/_authors/samuel.faure.md
+++ b/content/_authors/samuel.faure.md
@@ -6,6 +6,7 @@ missions:
   - start: '2017-04-24'
     end: '2019-12-31'
     status: admin
+    employer: dinum
 startups:
     - api-entreprise
 ---

--- a/content/_authors/sebastian.sachetti.md
+++ b/content/_authors/sebastian.sachetti.md
@@ -5,6 +5,7 @@ missions:
   - start: '2017-04-10'
     end: '2018-06-01'
     status: admin
+    employer: dinum
 startups:
 previously:
   - mrs

--- a/content/_authors/sylvain.dermy.md
+++ b/content/_authors/sylvain.dermy.md
@@ -9,9 +9,11 @@ missions:
   - start: '2017-03-01'
     end: '2018-02-28'
     status: admin
+    employer: dinum
   - start: '2018-04-01'
     end: '2019-11-30'
     status: admin
+    employer: dinum
 startups:
   - aplus
 previously:

--- a/content/_authors/thomas.guillet.md
+++ b/content/_authors/thomas.guillet.md
@@ -10,9 +10,11 @@ missions:
   - start: 2017-12-27
     end: 2019-12-04
     status: admin
+    employer: dinum
   - start: 2019-12-06
     end: 2020-12-24
     status: admin
+    employer: dinum
 startups:
   - mes-aides
   - voir-et-localiser

--- a/content/_authors/tiffany.yozgadalian.md
+++ b/content/_authors/tiffany.yozgadalian.md
@@ -5,6 +5,7 @@ missions:
   - start: '2017-07-01'
     end: '2017-10-31'
     status: admin
+    employer: dinum
 startups:
 previously:
   - place-des-entreprises

--- a/content/_authors/vincent.b.md
+++ b/content/_authors/vincent.b.md
@@ -5,6 +5,7 @@ missions:
   - start: '2015-03-01'
     end: '2019-12-31'
     status: admin
+    employer: dinum
 startups:
     - data.gouv.fr
     - le-taxi

--- a/content/_authors/zohra.lebel.md
+++ b/content/_authors/zohra.lebel.md
@@ -9,6 +9,7 @@ missions:
   - end: '2021-06-30'
     start: '2018-07-01'
     status: admin
+    employer: dinum
 startups:
   - aplus
 ---

--- a/content/_incubators/apigouv.md
+++ b/content/_incubators/apigouv.md
@@ -1,14 +1,16 @@
 ---
 title: L'Incubateur des API
-owner: DINSIC
+owner: DINUM
 website: https://api.gouv.fr/
 github: https://github.com/betagouv/api.gouv.fr
 contact: https://api.gouv.fr/contact
 address: 20 avenue de Ségur, Paris 7e
+redirect_from:
+  - /incubators/api_dinsic
 ---
 
 L'incubateur des API: 
-* rassemble les APIs de la DINSIC
+* rassemble les APIs de la DINUM
 * valorise les APIs des administrations
 * simplifie les démarches en ligne à travers la circulation des données
 * accompagne les producteur de données dans la mise à disposition de leurs propres API

--- a/content/_incubators/dinum.md
+++ b/content/_incubators/dinum.md
@@ -5,6 +5,9 @@ website: https://beta.gouv.fr/
 github: https://github.com/betagouv/
 contact: https://beta.gouv.fr/contact/
 address: 20 avenue de Ségur, Paris 7e
+redirect_from:
+  - /incubators/dinsic
+
 ---
 
 L'incubateur interministériel à l'origine du concept de Startups d’État. Il accueille également les Startups qui ne disposent pas encore d'incubateur dans leur administration.

--- a/content/_incubators/fabnumdef.md
+++ b/content/_incubators/fabnumdef.md
@@ -8,4 +8,4 @@ address: 60 Boulevard du Général Martial Valin, 75015 Paris
 
 ![Logo de la Fabrique numérique Défense Connect](https://github.com/fabnumdef/resources/raw/master/logo_fabnum_medium.png "Fabrique numérique Défense Connect")
 
-La Fabrique Numérique Défense Connect est l'incubateur de services numériques du ministère des Armées. Inspirés par l'incubateur interministériel de la DINSIC et les autres incubateurs ministériels, nous développons en mode agile des services numériques centrés sur les utilisateurs.
+La Fabrique Numérique Défense Connect est l'incubateur de services numériques du ministère des Armées. Inspirés par l'incubateur interministériel de la DINUM et les autres incubateurs ministériels, nous développons en mode agile des services numériques centrés sur les utilisateurs.

--- a/content/_jobs/2019-04-16-cto-auvol.md
+++ b/content/_jobs/2019-04-16-cto-auvol.md
@@ -24,7 +24,7 @@ Notre feuille de route est guidée par les besoins de nos utilisateurs et par no
 
 Au titre de Startup d’État, l’équipe de Saisissez au vol ! fait partie de la communauté beta.gouv.fr, qui réunit plus de 200 personnes au profil d’innovateur, d’entrepreneur ou d’intrapreneur publics travaillant au sein d’administrations.
 
-En rejoignant Saisissez au vol ! qui est incubée à la DINSIC, dans l’un des incubateurs de la communauté, vous rejoindrez donc une communauté profondément pluridisciplinaire, qui s’efforcera de vous fournir tout le soutien nécessaire à la résolution de vos problèmes au quotidien. Vous pourrez notamment participer à ses formations, ses ateliers de partage d’expérience, etc.
+En rejoignant Saisissez au vol ! qui est incubée à la DINUM, dans l’un des incubateurs de la communauté, vous rejoindrez donc une communauté profondément pluridisciplinaire, qui s’efforcera de vous fournir tout le soutien nécessaire à la résolution de vos problèmes au quotidien. Vous pourrez notamment participer à ses formations, ses ateliers de partage d’expérience, etc.
 
 ## Le produit
 

--- a/content/_jobs/2019-09-27-dinsic-portfolio.md
+++ b/content/_jobs/2019-09-27-dinsic-portfolio.md
@@ -1,10 +1,10 @@
 ---
 roles: deux responsables de portefeuilles
-title: "L'incubateur de la DINSIC recherche : deux responsables de portefeuilles"
+title: "L'incubateur de la DINUM recherche : deux responsables de portefeuilles"
 open: false
 ---
 
-L'incubateur de la DINSIC recrute des responsables de portefeuilles pour participer à la mise en place d'une équipe dédiée, autonome et pluridisciplinaire qui se donne pour mission de participer à la réussite du programme beta.gouv.fr
+L'incubateur de la DINUM recrute des responsables de portefeuilles pour participer à la mise en place d'une équipe dédiée, autonome et pluridisciplinaire qui se donne pour mission de participer à la réussite du programme beta.gouv.fr
 
 <!--more-->
 
@@ -12,7 +12,7 @@ L'incubateur de la DINSIC recrute des responsables de portefeuilles pour partici
 
 La communauté beta.gouv.fr à, depuis la création de la première Startup d'État, décidé collectivement que la meilleure manière de mettre en oeuvre une politique publique passe par la constitution d'une équipe autonome. Cette équipe est elle-même constituée de membres issus du public ou du privé qui se donnent pour mission de résoudre les problèmes de ses usagers. Elle pilote son action au jour le jour pour atteindre son objectif. Et enfin, elle répond de ses actes de façon transparente envers ses sponsors et ses usagers.
 
-Nous souhaitons construire, au sein de l'incubateur de la DINSIC, une équipe dédiée à l'accompagnement de ce programme qui respectera ces principes. Cette équipe aura pour mission de garantir à toutes les équipes de la communauté, celles de Startup d’État ainsi que celles des incubateurs ministériels qui le souhaitent, les conditions nécessaires à leur réussite, à diffuser cette culture dans de nouvelles administrations et à favoriser la naissance de produits innovants.
+Nous souhaitons construire, au sein de l'incubateur de la DINUM, une équipe dédiée à l'accompagnement de ce programme qui respectera ces principes. Cette équipe aura pour mission de garantir à toutes les équipes de la communauté, celles de Startup d’État ainsi que celles des incubateurs ministériels qui le souhaitent, les conditions nécessaires à leur réussite, à diffuser cette culture dans de nouvelles administrations et à favoriser la naissance de produits innovants.
 
 ## Missions
 
@@ -48,10 +48,10 @@ Vous avez :
 
 ## Modalités
 
-Poste ouvert à temps plein au sein de l'incubateur DINSIC, sous forme de CDD ou de mission pour les agents publics titulaires, pour une durée initiale de 3 ans. Démarrage dès que possible.
+Poste ouvert à temps plein au sein de l'incubateur DINUM, sous forme de CDD ou de mission pour les agents publics titulaires, pour une durée initiale de 3 ans. Démarrage dès que possible.
 
 ## Candidater
 
-Expliquez-nous pourquoi vous avez envie d'intégrer cette équipe et envoyez-nous votre LinkedIn, CV ou GitHub, le tout à dinsic@beta.gouv.fr
+Expliquez-nous pourquoi vous avez envie d'intégrer cette équipe et envoyez-nous votre LinkedIn, CV ou GitHub, le tout à dinum@beta.gouv.fr
 
 À bientôt !

--- a/content/_jobs/2019-10-29-transport_bizdev.md
+++ b/content/_jobs/2019-10-29-transport_bizdev.md
@@ -22,7 +22,7 @@ Nous sommes aujourd’hui une équipe de 7 personnes : 3 développeurs (Antoine,
 
 L’équipe est financée par le Ministère chargé des Transports qui nous laisse une autonomie totale sur la communication, l’agenda, les outils utilisés, la gestion du budget et les recrutements. En particulier, nous n’exécutons pas de cahier des charges, ne dépendons pas de circuits de validation et tentons de limiter les réunions internes au strict minimum pour laisser le temps à chacun de s’organiser comme il s’entend pour être le plus efficace possible.
 
-Nous travaillons à l’incubateur de services numériques de la Direction interministérielle du numérique (DINSIC), mais avons de nombreuses interactions avec les équipes voisines d’Etalab (qui sont notamment en charge de l’ouverture des données publiques et qui gèrent la plateforme data.gouv.fr). Notre feuille de route est guidée par les besoins de nos utilisateurs et par notre objectif partagé de rendre l’ouverture des données tranport la plus rapide et la plus utile possible pour améliorer l’information des voyageurs sur l’ensemble du territoire français, dans les grandes métropoles comme dans les zones rurales.
+Nous travaillons à l’incubateur de services numériques de la Direction interministérielle du numérique (DINUM), mais avons de nombreuses interactions avec les équipes voisines d’Etalab (qui sont notamment en charge de l’ouverture des données publiques et qui gèrent la plateforme data.gouv.fr). Notre feuille de route est guidée par les besoins de nos utilisateurs et par notre objectif partagé de rendre l’ouverture des données tranport la plus rapide et la plus utile possible pour améliorer l’information des voyageurs sur l’ensemble du territoire français, dans les grandes métropoles comme dans les zones rurales.
 
 Nos bureaux sont à Paris, avenue de Ségur, mais nous travaillons ponctuellement d’un peu partout. Nous sommes profondément intégrés à la communauté beta.gouv.fr, interagissons régulièrement avec d’autres équipes intervenant sur d’autres Startups d’État pour partager nos expériences respectives et participons fréquemment au standup et au séminaire.
 
@@ -36,7 +36,7 @@ Par notre travail, nous cherchons à montrer que des équipes autonomes, respons
 
 Au titre de Startup d’État, l’équipe de transport.data.gouv.fr fait partie de la communauté beta.gouv.fr, qui réunit plus de 250 personnes au profil d’innovateur, d’entrepreneur ou d’intrapreneur publics travaillant au sein d’administrations et qui se conforment à notre manifeste.
 
-En rejoignant transport.data.gouv.fr qui est incubée à la DINSIC, dans l’un des 6 incubateurs du réseau beta.gouv.fr, vous rejoindrez une communauté profondément pluridisciplinaire, qui s’efforcera de vous fournir tout le soutien nécessaire à la résolution de vos problèmes au quotidien. Vous pourrez notamment participer à ses formations, ses ateliers de partage d’expérience, et bien sûr à ses pots, en général les mercredis soirs.
+En rejoignant transport.data.gouv.fr qui est incubée à la DINUM, dans l’un des 6 incubateurs du réseau beta.gouv.fr, vous rejoindrez une communauté profondément pluridisciplinaire, qui s’efforcera de vous fournir tout le soutien nécessaire à la résolution de vos problèmes au quotidien. Vous pourrez notamment participer à ses formations, ses ateliers de partage d’expérience, et bien sûr à ses pots, en général les mercredis soirs.
 
 ### Le produit
 

--- a/content/_jobs/2020-04-16-chef-fe-produit.md
+++ b/content/_jobs/2020-04-16-chef-fe-produit.md
@@ -64,10 +64,10 @@ Intervention en appui des équipes sur plusieurs services du portefeuille beta.g
 
 ## Modalités
 
-Poste ouvert à temps plein au sein de l'incubateur DINSIC, sous forme de CDD ou de mission pour les agents publics titulaires, pour une durée initiale de 3 ans. Démarrage dès que possible.
+Poste ouvert à temps plein au sein de l'incubateur DINUM, sous forme de CDD ou de mission pour les agents publics titulaires, pour une durée initiale de 3 ans. Démarrage dès que possible.
 
 ## Candidater
 
-Expliquez-nous pourquoi vous avez envie d'intégrer cette équipe et envoyez-nous votre LinkedIn, CV ou GitHub, le tout à dinsic@beta.gouv.fr
+Expliquez-nous pourquoi vous avez envie d'intégrer cette équipe et envoyez-nous votre LinkedIn, CV ou GitHub, le tout à dinum@beta.gouv.fr
 
 À bientôt !

--- a/content/_mooc/sequence-5-industriel-milieu-artisanal.md
+++ b/content/_mooc/sequence-5-industriel-milieu-artisanal.md
@@ -30,6 +30,6 @@ order: 5
   <div class="video-iframe-container">
     <iframe src="https://www.dailymotion.com/embed/video/x6xkf63" allowfullscreen></iframe>
   </div>
-  <p>Philippe Vrignaud - Directeur de projets DINSIC et Serial Intrapreur beta.gouv.fr</p>
+  <p>Philippe Vrignaud - Directeur de projets DINUM et Serial Intrapreur beta.gouv.fr</p>
   <p><a href="/content/docs/mooc/23-lancez-vous-avec-demarches-simplifiees.pdf" target="\_blank">Télécharger le texte de cette vidéo</a></p>
 </div>

--- a/content/_startups/aidantsconnect.md
+++ b/content/_startups/aidantsconnect.md
@@ -2,7 +2,7 @@
 title: Aidants Connect
 mission: Permettre à un aidant professionnel de réaliser des démarches administratives en ligne à la place d’une personne ne parvenant pas à les faire seule.
 owner: Agence du Numérique
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2019-03-13
 end:

--- a/content/_startups/andi.md
+++ b/content/_startups/andi.md
@@ -2,7 +2,7 @@
 title: ANDi
 mission: Faciliter l'immersion professionnelle des personnes en situation de handicap
 owner: Caisse des dépôts 
-incubator: dinsic 
+incubator: dinum
 status: construction
 start: 2019-05-16 
 end: 2020-05-15

--- a/content/_startups/api-drones.md
+++ b/content/_startups/api-drones.md
@@ -2,7 +2,7 @@
 title: API Drones
 mission: Une meilleure connaissance du ciel pour plus de sécurité et d'innovation
 owner: SGDSN
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2017-06-01
 end:

--- a/content/_startups/api-entreprise.md
+++ b/content/_startups/api-entreprise.md
@@ -1,8 +1,8 @@
 ---
 title: API Entreprise
 mission: Récupérer les données des entreprises
-owner: DINSIC
-incubator: api_dinsic
+owner: DINUM
+incubator: apigouv
 status: alumni
 start: 2014-01-01
 end:

--- a/content/_startups/api-geo.md
+++ b/content/_startups/api-geo.md
@@ -1,8 +1,8 @@
 ---
 title: API Géo
 mission: Interrogez les référentiels géographiques plus facilement
-owner: DINSIC
-incubator: api_dinsic
+owner: DINUM
+incubator: apigouv
 status: alumni
 start: 2015-01-01
 end:

--- a/content/_startups/api-particulier.md
+++ b/content/_startups/api-particulier.md
@@ -1,8 +1,8 @@
 ---
 title: API Particulier
 mission: Accélérer l’ouverture des données personnelles et leur réutilisation pour simplifier les démarches
-owner: DINSIC
-incubator: api_dinsic
+owner: DINUM
+incubator: apigouv
 status: alumni
 start: 2015-10-11
 end:

--- a/content/_startups/api.gouv.fr.md
+++ b/content/_startups/api.gouv.fr.md
@@ -1,8 +1,8 @@
 ---
 title: api.gouv.fr
 mission: Faciliter l'accès aux API publiques pour faire émerger de nouveaux services
-owner: DINSIC
-incubator: api_dinsic
+owner: DINUM
+incubator: apigouv
 status: alumni
 start: 2016-01-25
 end:

--- a/content/_startups/aplus.md
+++ b/content/_startups/aplus.md
@@ -2,7 +2,7 @@
 title: Administration+, le service public VIP pour tous
 mission: Résoudre les blocages administratifs inextricables
 owner: DINUM
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2017-10-01
 end:

--- a/content/_startups/apprentissage.md
+++ b/content/_startups/apprentissage.md
@@ -2,7 +2,7 @@
 title: Mission Apprentissage
 mission: Faciliter les entrées en apprentissage
 owner: Délégation générale à l'emploi et à la formation professionnelle (DGEFP)
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2019-11-01
 end:

--- a/content/_startups/auvol.md
+++ b/content/_startups/auvol.md
@@ -2,7 +2,7 @@
 title: Saisissez au vol !
 mission: Soutenir les agents qui assurent la sécurité aérienne
 owner: DGAC
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2019-03-01
 end:

--- a/content/_startups/ban.md
+++ b/content/_startups/ban.md
@@ -2,7 +2,7 @@
 title: Base Adresse Nationale
 mission: Référencer l'intégralité des adresses du territoire français
 owner: Etalab
-incubator: dinsic
+incubator: dinum
 status: success
 start: 2014-06-01
 end:

--- a/content/_startups/bourse.md
+++ b/content/_startups/bourse.md
@@ -1,8 +1,8 @@
 ---
 title: Bourse
 mission: Demander et liquider une bourse de collège en ligne
-owner: DINSIC
-incubator: dinsic
+owner: DINUM
+incubator: dinum
 status: alumni
 start: 2015-03-01
 end:

--- a/content/_startups/boussole.md
+++ b/content/_startups/boussole.md
@@ -2,7 +2,7 @@
 title: Boussole des droits
 mission: Accéder à des conseils professionnels à proximité pour trouver un logement, une formation ou un emploi
 owner: Direction de la jeunesse
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2015-12-01
 end:
@@ -47,7 +47,7 @@ Le code source que nous publions [ici](https://github.com/betagouv/boussole) cor
 
 ## La fiche produit publiée en 2016
 
-Depuis 2013, un travail d’analyse et d’étude a été mené par la <abbr title="Direction de la jeunesse, de l’éducation populaire et de la vie associative">DJEPVA</abbr> et le <abbr title="direction interministérielle du numérique et du système d'information et de communication de l'État">DINSIC</abbr> sur 2 territoires pilotes (Reims et Rennes), pour identifier les besoins des jeunes dans leur accès à l’information et les attentes des professionnels de l’Information Jeunesse en ce qui concerne l’évolution de leur pratique.
+Depuis 2013, un travail d’analyse et d’étude a été mené par la <abbr title="Direction de la jeunesse, de l’éducation populaire et de la vie associative">DJEPVA</abbr> et la <abbr title="direction interministérielle du numérique et du système d'information et de communication de l'État">DINSIC</abbr> sur 2 territoires pilotes (Reims et Rennes), pour identifier les besoins des jeunes dans leur accès à l’information et les attentes des professionnels de l’Information Jeunesse en ce qui concerne l’évolution de leur pratique.
 
 En synthèse, ce travail a montré que les jeunes recherchent de l’information de « proximité » (parents, amis), « en réaction » (à un besoin, un projet) et dans l’urgence. Ils accordent une confiance à l’information publique et de la valeur à l’opinion de leurs pairs.
 

--- a/content/_startups/cartobio.md
+++ b/content/_startups/cartobio.md
@@ -2,7 +2,7 @@
 title: Cartobio
 mission: Ouvrir, enrichir et partager les données parcellaires de l’agriculture biologique
 owner: Agence Française pour le Développement et la Promotion de l'Agriculture Biologique (Agence Bio)
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2019-12-19
 end:

--- a/content/_startups/classes12.md
+++ b/content/_startups/classes12.md
@@ -2,7 +2,7 @@
 title: Classes à 12
 mission: Faciliter le passage en classe à 12 pour les enseignants et maximiser la valeur de ce dispositif pour les élèves.
 owner: Ministère de l'Éducation nationale
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2018-06-01
 end:

--- a/content/_startups/cmachance.md
+++ b/content/_startups/cmachance.md
@@ -2,7 +2,7 @@
 title: Cmachance 
 mission: Augmenter le nombre d'apprentis dans l'artisanat 
 owner: Chambre de Métiers et de l'Artisanat Hauts-de-France
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2020-03-15
 end:

--- a/content/_startups/data.gouv.fr.md
+++ b/content/_startups/data.gouv.fr.md
@@ -2,7 +2,7 @@
 title: data.gouv.fr
 mission: Partager, améliorer et réutiliser les données publiques
 owner: Etalab
-incubator: dinsic
+incubator: dinum
 status: success
 start: 2013-06-01
 end:

--- a/content/_startups/demarches-simplifiees.fr.md
+++ b/content/_startups/demarches-simplifiees.fr.md
@@ -1,8 +1,8 @@
 ---
 title: demarches-simplifiees.fr
 mission: Dématérialiser n’importe quelle démarche administrative en quelques minutes
-owner: DINSIC
-incubator: dinsic
+owner: DINUM
+incubator: dinum
 status: success
 start: 2015-09-15
 end:
@@ -62,6 +62,6 @@ demarches-simplifiees.fr est pour vous.
 
 **Contact**
 
-demarches-simplifiees.fr est développé par l’incubateur de services numériques de la direction interministérielle du numérique et du système d'information et de communication de l'État (DINSIC), rattaché aux services du Premier ministre.
+demarches-simplifiees.fr est développé par l’incubateur de services numériques de la direction interministérielle du numérique (DINUM), rattaché aux services du Premier ministre.
 
 Vous voulez en savoir plus ? Vous voulez une démo ? <a href="https://www.demarches-simplifiees.fr/contact">Contactez-nous</a>.

--- a/content/_startups/diagoriente.md
+++ b/content/_startups/diagoriente.md
@@ -2,7 +2,7 @@
 title: DiagOriente
 mission: Permettre aux jeunes en difficulté de découvrir leurs compétences et leurs aspirations
 owner: Haut-commissaire aux compétences et à l’inclusion par l’emploi
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2018-06-06
 end:

--- a/content/_startups/disinfo.md
+++ b/content/_startups/disinfo.md
@@ -2,7 +2,7 @@
 title: Disinfo
 mission: Diminuer la quantité de désinformation à laquelle un individu est confronté quotidiennement
 owner: Ambassadeur pour le numérique
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2019-01-10
 end:

--- a/content/_startups/dossiersco.md
+++ b/content/_startups/dossiersco.md
@@ -2,7 +2,7 @@
 title: DossierSCO
 mission: Inscrire son enfant au collège en quelques clics
 owner: Ministère de l'Éducation nationale
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2017-09-01
 end: 2019-09-15

--- a/content/_startups/e-controle.md
+++ b/content/_startups/e-controle.md
@@ -2,7 +2,7 @@
 title: E-contrôle
 mission: Simplifier les échanges de documents entre un organisme de contrôle et les organisations contrôlées.
 owner: Cour des comptes
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2018-09-03
 end:

--- a/content/_startups/eac.md
+++ b/content/_startups/eac.md
@@ -2,7 +2,7 @@
 title : Plateforme EAC
 mission: Augmenter le nombre d'actions artistiques et culturelles pour les jeunes dans les établissements scolaires
 owner: Ministère de la Culture
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2018-04-01
 end:

--- a/content/_startups/ecolab.md
+++ b/content/_startups/ecolab.md
@@ -2,7 +2,7 @@
 title: Ecolab
 mission:  Apporter l'information environnementale au plus près des citoyens
 owner: ADEME
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2019-01-02 
 end: 

--- a/content/_startups/ecosante.md
+++ b/content/_startups/ecosante.md
@@ -2,7 +2,7 @@
 title: Ecosanté
 mission: Réduire l’exposition aux facteurs environnementaux nocifs pour la santé
 owner: Ministère de la Santé - Ministère de la Transition Écologique et Solidaire
-incubator: dinsic 
+incubator: dinum
 status: construction
 start: 2019-11-25 
 end: 

--- a/content/_startups/etudiant-entrepreneur.md
+++ b/content/_startups/etudiant-entrepreneur.md
@@ -2,7 +2,7 @@
 title: Étudiant entrepreneur
 mission: Faciliter l'accès au statut étudiant entrepreneur et à ses bénéfices
 owner: Ministère de l'Enseignement supérieur
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2016-06-23
 end:

--- a/content/_startups/eva.md
+++ b/content/_startups/eva.md
@@ -3,7 +3,7 @@ title: eva (anciennement Compétences pro)
 mission: Favoriser l’insertion en détectant les compétences transversales et valorisant les potentiels à travers un outil de mise en situation numérique
 
 owner: Haut-commissaire aux compétences et à l’inclusion par l’emploi - DGEFP
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2018-06-06
 end:

--- a/content/_startups/fiches-de-banc.md
+++ b/content/_startups/fiches-de-banc.md
@@ -1,8 +1,8 @@
 ---
 title: Fiches de banc
 mission: Augmenter la productivité du traitement des amendements dans les cabinets ministériels
-owner: DINSIC
-incubator: dinsic
+owner: DINUM
+incubator: dinum
 status: alumni
 start: 2015-01-12
 end:

--- a/content/_startups/friches.md
+++ b/content/_startups/friches.md
@@ -2,7 +2,7 @@
 title: Friches
 mission: Faciliter la réhabilitation des friches
 owner: CEREMA
-incubator: dinsic
+incubator: dinum
 status: investigation
 start: 2020-02-12
 end: 

--- a/content/_startups/geo.data.gouv.fr.md
+++ b/content/_startups/geo.data.gouv.fr.md
@@ -2,7 +2,7 @@
 title: geo.data.gouv.fr
 mission: Trouver facilement les données géographiques dont vous avez besoin
 owner: Etalab
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2015-01-01
 end:

--- a/content/_startups/gps-usagers.md
+++ b/content/_startups/gps-usagers.md
@@ -2,7 +2,7 @@
 title: GPS usagers
 mission: Orienter les usagers qui souhaitent joindre le département du Calvados vers le bon interlocuteur et le bon moyen de communication
 owner: Département du Calvados
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2018-10-01
 end:

--- a/content/_startups/histologe.md
+++ b/content/_startups/histologe.md
@@ -2,7 +2,7 @@
 title: Histologe
 mission: Le Contrôle Technique Gratuit du Logement 
 owner: Agglomération de Pau Béarn Pyrénées
-incubator: dinsic 
+incubator: dinum
 status: construction
 start: 2019-09-01
 end: 

--- a/content/_startups/itou.md
+++ b/content/_startups/itou.md
@@ -2,7 +2,7 @@
 title: Itou
 mission: La réussite pour tous
 owner: la Délégation générale à l’emploi et à la formation professionnelle (DGEFP) & Pôle emploi, appuyé par le Haut-commissariat à l'inclusion dans l'emploi et à l'engagement des entreprises
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2019-06-10 # date au format ISO (AAAA-MM-DD)
 end: # laisser vide

--- a/content/_startups/lapins.md
+++ b/content/_startups/lapins.md
@@ -2,7 +2,7 @@
 title: RDV Solidarités (anciennement Lapins)
 mission: Réduire le nombre de rendez-vous annulés dans les maisons départementales de solidarité
 owner: Consortium de départements
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2018-01-18
 end: 
@@ -24,7 +24,7 @@ Les activités de la Protection Maternelle et Infantile (PMI) et d'accueil socia
 
 Les solutions trouvées pour le Pas-de-Calais ont vocation à être étendues, enrichies et partagées avec d'autres départements. Une rapide étude a confirmé l'existence de cette situation  dans un nombre considérable de départements. 
 
-En avril 2019, 12 collectivités départementales se sont associées pour former un consortium soutenu par la DINSIC, créer une plateforme commune et partager les bonnes pratiques. 
+En avril 2019, 12 collectivités départementales se sont associées pour former un consortium soutenu par la DINUM, créer une plateforme commune et partager les bonnes pratiques. 
 
 ## Une solution numérique pour faciliter la prise, l’annulation et le remplacement de rendez-vous
 

--- a/content/_startups/le-taxi.md
+++ b/content/_startups/le-taxi.md
@@ -2,7 +2,7 @@
 title: Le Taxi
 mission: Commander un taxi, rapidement
 owner: DGITM
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2015-03-15
 end:

--- a/content/_startups/leximpact.md
+++ b/content/_startups/leximpact.md
@@ -2,7 +2,7 @@
 title: LexImpact
 mission: Aider nos parlementaires à estimer les impacts de leurs amendements avant vote !
 owner: Assemblée nationale
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2019-01-21
 end: 2020-01-03

--- a/content/_startups/lotocar.md
+++ b/content/_startups/lotocar.md
@@ -2,7 +2,7 @@
 title: Lotocar
 mission: Permettre aux personnes isolées et parfois coupées d'internet de se déplacer sur les territoires peu denses
 owner: Ademe / Préfecture du Lot (46)
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2018-11-26
 end:

--- a/content/_startups/mdph.md
+++ b/content/_startups/mdph.md
@@ -2,7 +2,7 @@
 title: MDPH en ligne
 mission: Faciliter les demandes de compensation du handicap auprès des MDPH
 owner: Caisse nationale de solidarité pour l'autonomie (CNSA)
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2014-12-01
 end:

--- a/content/_startups/mes-aides.md
+++ b/content/_startups/mes-aides.md
@@ -1,8 +1,8 @@
 ---
 title: Mes Aides
 mission: Évaluer ses droits à 28 aides sociales. En moins de 7 minutes.
-owner: DINSIC
-incubator: dinsic
+owner: DINUM
+incubator: dinum
 status: alumni
 start: 2014-05-01
 end: 2020-03-03

--- a/content/_startups/mon-entreprise.md
+++ b/content/_startups/mon-entreprise.md
@@ -2,7 +2,7 @@
 title: Mon-entreprise.fr
 mission: "L'assistant officiel du créateur d'entreprise"
 owner: Acoss
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2014-10-01
 end:
@@ -53,4 +53,4 @@ Ce site s'appuiera sur le succès du *simulateur d'embauche*, intégré aujourd'
 
 ## Budget 💶
 
-La startup a un budget annuel pour l'année 2019 de _300 000 euros_ (tout compris, mais hors TVA), et bénéficie de l'aide précieuse de plusieurs agents de l'administration. La DINSIC et l'ACOSS se partagent le financement.
+La startup a un budget annuel pour l'année 2019 de _300 000 euros_ (tout compris, mais hors TVA), et bénéficie de l'aide précieuse de plusieurs agents de l'administration. La DINUM et l'ACOSS se partagent le financement.

--- a/content/_startups/monstage.md
+++ b/content/_startups/monstage.md
@@ -2,7 +2,7 @@
 title: Mon stage de 3e
 mission: Permettre aux élèves de 3e d'accéder à des stages pertinents et de qualité visant à accompagner leur émancipation et combattre les déterminismes sociaux
 owner: CGET
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2018-12-01
 end:

--- a/content/_startups/mpal.md
+++ b/content/_startups/mpal.md
@@ -2,7 +2,7 @@
 title: Les aides de l’Anah
 mission: Accéder rapidement et simplement aux aides à l’habitat privé
 owner: Agence nationale de l’habitat (Anah)
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2016-05-01
 end:

--- a/content/_startups/mps.md
+++ b/content/_startups/mps.md
@@ -1,8 +1,8 @@
 ---
 title: Marchés publics simplifiés
 mission: Candidater en ligne à un Marché Public avec uniquement son SIRET
-owner: DINSIC
-incubator: dinsic
+owner: DINUM
+incubator: dinum
 status: alumni
 start: 2014-01-01
 end:

--- a/content/_startups/mrs.md
+++ b/content/_startups/mrs.md
@@ -2,7 +2,7 @@
 title: Mes remboursements simplifiés (MRS)
 mission: Simplifier et accélérer le remboursement des frais d'utilisation du véhicule personnel ou des transports en commun
 owner: CNAMTS / CPAM de la Haute-Garonne (31)
-incubator: dinsic
+incubator: dinum
 status: consolidation
 start: 2017-10-01
 end:

--- a/content/_startups/ogptoolbox.md
+++ b/content/_startups/ogptoolbox.md
@@ -2,7 +2,7 @@
 title: OGP Toolbox
 mission: Trouver des outils numériques pour améliorer la démocratie
 owner: Etalab / Open Government Partnership
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2016-06-08
 end:

--- a/content/_startups/open-academie.md
+++ b/content/_startups/open-academie.md
@@ -2,7 +2,7 @@
 title: Open Académie
 mission: Construire le lycée et le collège de demain
 owner: Ministère de l'Éducation nationale
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2015-01-01
 end:

--- a/content/_startups/pass-culture.md
+++ b/content/_startups/pass-culture.md
@@ -2,7 +2,7 @@
 title : Pass Culture
 mission: Faciliter l'accès des jeunes à la culture
 owner: Ministère de la Culture
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2017-12-01
 end:

--- a/content/_startups/pau-partage.md
+++ b/content/_startups/pau-partage.md
@@ -2,7 +2,7 @@
 title: Pau Partage
 mission: Lutter contre l'isolement des personnes âgées en favorisant la rencontre avec des bénévoles
 owner: Agglomération de Pau Béarn Pyrénées
-incubator: dinsic 
+incubator: dinum
 status: investigation
 start: 2019-02-04
 end: 

--- a/content/_startups/peps.md
+++ b/content/_startups/peps.md
@@ -2,7 +2,7 @@
 title: Peps
 mission: Faciliter la transition du modèle agricole grâce au partage d'expériences entre agriculteurs
 owner: Ministère de l'Agriculture et de l'Alimentation - Ministère de la Transition Écologique et Solidaire
-incubator: dinsic 
+incubator: dinum
 status: construction
 start: 2019-05-13 
 end: 

--- a/content/_startups/permis-de-construire-facile.md
+++ b/content/_startups/permis-de-construire-facile.md
@@ -40,7 +40,7 @@ Le demandeur sera informé automatiquement et immédiatement de la décision con
 
 ## Les premières étapes 
 
-L’équipe analyse actuellement l’intérêt de se “raccorder” avec la solution “démarches simplifiées” portée par la DINSIC qui répond fonctionnellement à de nombreux aux éléments coeur envisagés dans le produit. L’articulation avec le produit ALDAU (Assistance en Ligne des Demandes d’Autorisation d’Urbanisme) sera également analysée.
+L’équipe analyse actuellement l’intérêt de se “raccorder” avec la solution “démarches simplifiées” portée par la DINUM qui répond fonctionnellement à de nombreux aux éléments coeur envisagés dans le produit. L’articulation avec le produit ALDAU (Assistance en Ligne des Demandes d’Autorisation d’Urbanisme) sera également analysée.
 
 L’ambition est de démarrer avec dépôt dématérialisé des déclarations préalables, actes simples qui représentent 70% des actes d’urbanisme instruits chaque année, soit près de 700 000, pour vérifier si le produit répond bien aux irritants identifiés.
 

--- a/content/_startups/pix.md
+++ b/content/_startups/pix.md
@@ -2,7 +2,7 @@
 title: Pix
 mission: Mesurer, développer et valoriser ses compétences numériques
 owner: GIP PIX
-incubator: dinsic
+incubator: dinum
 status: success
 start: 2016-06-08
 end:

--- a/content/_startups/place-des-entreprises.md
+++ b/content/_startups/place-des-entreprises.md
@@ -2,7 +2,7 @@
 title: Place des Entreprises
 mission: Apporter l’ensemble des aides publiques aux entreprises qui en ont besoin
 owner: DIRECCTE Haut-de-France
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2017-04-03
 end:

--- a/content/_startups/plante-et-moi.md
+++ b/content/_startups/plante-et-moi.md
@@ -1,8 +1,8 @@
 ---
 title: Plante & Moi
 mission: Augmenter la présence de la nature en ville
-owner: DINSIC
-incubator: dinsic
+owner: DINUM
+incubator: dinum
 status: construction
 start: 2016-10-01
 end:

--- a/content/_startups/pop.md
+++ b/content/_startups/pop.md
@@ -1,7 +1,7 @@
 ---
 title: Plateforme Ouverte du Patrimoine
 mission: Valoriser notre patrimoine culturel auprès du plus grand nombre
-incubator: dinsic
+incubator: dinum
 owner: Ministère de la Culture
 status: alumni
 start: 2018-04-01

--- a/content/_startups/poubelles-battle.md
+++ b/content/_startups/poubelles-battle.md
@@ -1,8 +1,8 @@
 ---
 title: Poubelles Battle
 mission: Faciliter le déploiement de composteurs collectifs et encourager leur utilisation
-incubator: dinsic
-owner: dinsic
+incubator: dinum
+owner: DINUM
 status: construction
 start: 2019-06-03
 end:

--- a/content/_startups/preuve-de-covoiturage.md
+++ b/content/_startups/preuve-de-covoiturage.md
@@ -2,7 +2,7 @@
 title: Registre de preuve de covoiturage
 mission:  Développez le covoiturage sur votre territoire
 owner: DGITM
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2018-06-04
 end:

--- a/content/_startups/psi.md
+++ b/content/_startups/psi.md
@@ -1,8 +1,8 @@
 ---
 title: Prélèvement à la source pour les indépendants
 mission: Simplifier radicalement le règlement des cotisations sociales par les indépendants
-owner: DINSIC
-incubator: dinsic
+owner: DINUM
+incubator: dinum
 status: alumni
 start: 2014-12-15
 end:
@@ -63,7 +63,7 @@ En réduisant considérablement le taux d'anomalies, nous libérons des gains im
 
 ### La démarche de mise en œuvre : héberger l'innovation
 
-Le dispositif de prélèvement à la source est une innovation radicale. L’État, par la DINSIC, s'est doté d'un savoir-faire en matière d'innovation à travers le concept de «&nbsp;Start-up d’État&nbsp;», celui-ci transpose les bonnes pratiques de l'innovation qui ont fait leurs preuves dans la nouvelle économie :
+Le dispositif de prélèvement à la source est une innovation radicale. L’État s'est doté d'un savoir-faire en matière d'innovation à travers le concept de «&nbsp;Start-up d’État&nbsp;», celui-ci transpose les bonnes pratiques de l'innovation qui ont fait leurs preuves dans la nouvelle économie :
 
 - L'engagement d'un dirigeant pour défendre l'innovation à travers son portage économique et l'adoption d'une attitude bienveillante : passer d'une logique de «&nbsp;pourquoi ?&nbsp;» à une logique de «&nbsp;pourquoi pas ?&nbsp;».
 - La mobilisation d'une équipe restreinte capable de développer rapidement, en méthode agile, le produit réglementaire et le système d'information support de l'innovation. L'expérience montre qu'il est nécessaire que cette équipe soit isolée de l'environnement opérationnel courant qui ne peut que tendre vers la reproduction ou à des arbitrages de ressources ou de calendrier défavorables.
@@ -72,6 +72,6 @@ Le dispositif de prélèvement à la source est une innovation radicale. L’Ét
 - L'arrêt de l'innovation dés lors qu'elle ne rencontre pas un marché pour limiter les risques économiques et les «&nbsp;fausses bonnes idées&nbsp;».
 La reprise du produit par un acteur de taille importante, ici l'ACOSS a priori, après 18 à 24 mois d’incubation.
 
-La Startup d'État peut être hébergée à la DINSIC, dans un ministère ou un établissement doté d'une entité d'accueil de l'innovation ou souhaitant la créer. Le champ d'expérimentation doit plutôt être délimité par le volontariat des usagers que par une obligation sur un territoire. Cibler les nouveaux indépendants créateurs d'entreprise permettra d'éviter les difficultés liées à des reprises d'historique.
+La Startup d'État peut être hébergée dans un incubateur d'État, dans un ministère ou un établissement doté d'une entité d'accueil de l'innovation ou souhaitant la créer. Le champ d'expérimentation doit plutôt être délimité par le volontariat des usagers que par une obligation sur un territoire. Cibler les nouveaux indépendants créateurs d'entreprise permettra d'éviter les difficultés liées à des reprises d'historique.
 
 La gouvernance du projet s'appuiera sur le modèle des startups d'État, c'est à dire constituée d'une équipe pluridisciplinaire autonome sur le produit et pilotée stratégiquement par un comité sponsor réunissant les représentants des ministères de tutelle, du parlement, de la Sécurité sociale pour les indépendants, de l’ACOSS, des chambres consulaires, des organismes conventionnés…

--- a/content/_startups/reserve-civique.md
+++ b/content/_startups/reserve-civique.md
@@ -2,7 +2,7 @@
 title: Réserve civique
 mission: Donner de son temps pour l'intérêt général
 owner: Haut-commissariat à l'engagement civique
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2017-03-23
 end:

--- a/content/_startups/retraite.md
+++ b/content/_startups/retraite.md
@@ -2,7 +2,7 @@
 title: Mes démarches retraite pas à pas
 mission: Obtenir en quelques clics la liste personnalisée de ses démarches de retraite
 owner: CNAV, MSA, Sécurité sociale pour les indépendants
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2015-10-01
 end:

--- a/content/_startups/reuni.md
+++ b/content/_startups/reuni.md
@@ -2,7 +2,7 @@
 title: Reuni
 mission: Permettre aux agents publics d'accéder simplement aux documents qu'ils recherchent
 owner: Direction générale des entreprises
-incubator: dinsic 
+incubator: dinum
 status: alumni
 start: 2018-12-01 
 end: 

--- a/content/_startups/signalement.md
+++ b/content/_startups/signalement.md
@@ -2,7 +2,7 @@
 title: SignalConso
 mission: Faire baisser le nombre d'anomalies rencontrées par les consommateurs
 owner: Direction générale de la concurrence, de la consommation et de la répression des fraudes (DGCCRF)
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2018-06-18
 end:

--- a/content/_startups/signaux-faibles.md
+++ b/content/_startups/signaux-faibles.md
@@ -1,8 +1,8 @@
 ---
 title: Signaux Faibles
 mission: Mieux cibler les interventions en remédiation de l’État vers les entreprises en difficulté
-owner: DINSIC
-incubator: dinsic
+owner: DINUM
+incubator: dinum
 status: consolidation
 start: 2014-05-15
 end:

--- a/content/_startups/trait-d-union.md
+++ b/content/_startups/trait-d-union.md
@@ -2,7 +2,7 @@
 title: Trait d'Union
 mission: Permettre aux demandeurs d'emploi d'essayer des métiers qui recrutent et forment à côté de chez eux
 owner: Région Grand Est
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2019-01-01
 end:

--- a/content/_startups/transport.md
+++ b/content/_startups/transport.md
@@ -2,7 +2,7 @@
 title: transport.data.gouv.fr
 mission: De l’information voyageur pour tous, partout en France, grâce à l’ouverture des données.
 owner: DGITM
-incubator: dinsic
+incubator: dinum
 status: acceleration
 start: 2017-07-03
 end:

--- a/content/_startups/urbaclic.md
+++ b/content/_startups/urbaclic.md
@@ -2,7 +2,7 @@
 title: Urbaclic
 mission: Accéder aux règles d'urbanisme en quelques clics
 owner: SGAR Occitanie, Etalab
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2016-03-01
 end:

--- a/content/_startups/visam.md
+++ b/content/_startups/visam.md
@@ -2,7 +2,7 @@
 title: Visam
 mission: Fluidifier le dialogue social de la  « Direction des ressources humaines » de l’État.
 owner: DGAFP
-incubator: dinsic
+incubator: dinum
 status: construction
 start: 2020-02-20
 end:

--- a/content/_startups/voir-et-localiser.md
+++ b/content/_startups/voir-et-localiser.md
@@ -2,7 +2,7 @@
 title: Voir & Localiser
 mission: Voir et localiser les appelants aux centres d'appels d'urgence
 owner: ASIP Santé - Agence Française de la Santé Numérique
-incubator: dinsic
+incubator: dinum
 status: alumni
 start: 2018-11-20
 end:

--- a/content/_startups/zam.md
+++ b/content/_startups/zam.md
@@ -1,8 +1,8 @@
 ---
 title: Zam
 mission: Alléger la charge de préparation par le gouvernement du débat parlementaire.
-owner: DINSIC
-incubator: dinsic
+owner: DINUM
+incubator: dinum
 status: acceleration
 start: 2018-03-28
 end:

--- a/content/templates/authors.md
+++ b/content/templates/authors.md
@@ -11,7 +11,7 @@ link: # optionnel : lien vers une page perso externe.
 missions: # ton historique de missions avec nous dans l'ordre chronologique. Remplis déjà la première pour commencer !
   - start: '2019-01-01' # date d'arrivée au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
     end: '2019-12-31' # date de fin de contrat au format ISO (AAAA-MM-JJ) - pense à bien garder les '' !
-    status: # dinsic (pour agent DINSIC) ou independent (pour indépendant) ou admin (pour agent d'une autre administration) ou service (pour société de service)
+    status:
     employer: # si applicable, le nom de ton administration, SSII, etc.
 startups: # ta ou tes startups actuelles
     - super_startup # le nom du fichier de la startup dans le répertoire /content/_startups/ sans l'extension .md

--- a/content/templates/startups.md
+++ b/content/templates/startups.md
@@ -1,8 +1,8 @@
 ---
 title: Mes Aides # une majuscule et pas d'acronymes
 mission: Accéder aux conseils de professionnels à proximité pour trouver un logement # infinitif, pas de point ; compléter la phrase « En investissant dans ce produit l'État cherche à… »
-owner: DINSIC # Administration porteuse
-incubator: dinsic # le nom du fichier de l'incubateur de la startup
+owner: DINUM # Administration porteuse
+incubator: dinum # le nom du fichier de l'incubateur de la startup
 status: consolidation # les phases possibles sont définies dans /content/_phases/
 start: 2015-01-15 # date au format ISO (AAAA-MM-DD)
 end: # laisser vide


### PR DESCRIPTION
C'est l'heure du grand renommage de printemps…

J'ai choisi d'opérer un maximum de remplacements `s/DINSIC/DINUM/g` et apparentés, en prenant le risque attenant à modifier beaucoup de fichiers à la fois: c'est pour atténuer un autre risque, celui qu'en conservant les deux acronymes les gens se trompent… car il y en a (comme moi) qui s'inspirent des fichiers existants pour savoir ce qu'il faut écrire dans un nouveau. ;)

J'ai opéré quelques corrections opportunistes à la marge, notamment supprimé deux `employer: dinum` qui auraient dû être des `status: dinum` (même si ce choix est contestable, j'ouvre une issue à part).

ETA: le codage des personnels (stagiaires ou contractuels) de la DISIC, DINSIC ou DINUM est désormais status: admin, employer: dinum par souci de cohérence.