### PR TITLE
Corrige l'affichage de certains membres

### DIFF
--- a/_layouts/communaute.html
+++ b/_layouts/communaute.html
@@ -37,13 +37,14 @@ layout: default
 {%- endcapture -%}
 {%- assign authors_active = authors_active | append: to_append -%}
 
-{%- for start_date in start_dates -%}
-  {%- if start_date > build_date -%}
+{%- for selected_date in start_dates -%}
+  {%- if selected_date > build_date -%}
     {%- continue -%}
   {%- endif -%}
   {%- for author in authors -%}
-    {%- if author.missions.first.start == start_date -%}
-      {%- capture end_date_as_string -%}{{ author.missions.last.end }}{%- endcapture -%}
+    {%- capture end_date_as_string -%}{{ author.missions.last.end }}{%- endcapture -%}
+    {%- capture start_date_as_string -%}{{ author.missions.first.start }}{%- endcapture -%}
+    {%- if start_date_as_string == selected_date -%}
       {%- if end_date_as_string == '' or end_date_as_string > build_date -%}
         {%- capture to_append -%}
           {%- include card-community.html author=author -%}


### PR DESCRIPTION
Faute de forcer la date de début de première mission au type chaîne, ou d'avoir systématisé cette conversion dans les fiches membres, certaines personnes de la communauté (trois au total) n'apparaissaient plus dans la page `/communaute`.

Cette PR opte pour la robustesse dans la mesure où il ne semble pas réaliste d'exclure que de nouvelles fiches soient créées ou mises à jour avec des dates au format problématique:
```
missions:
  - start: 2017-03-06
    end: 2017-12-26
    status: independent
```
…plutôt que dans le format attendu (avec guillemets):

```
missions:
  - start: '2017-03-06'
    end: '2017-12-26'
    status: independent
```