### PR TITLE
Update apprentissage.md

### DIFF
--- a/content/_startups/apprentissage.md
+++ b/content/_startups/apprentissage.md
@@ -36,4 +36,4 @@ D'ores et déja de premières actions ont été réalisées pour la campagne d'i
 
 *Guillaume Houzel, inspecteur général œuvrant pour l'éducation et l'accès à l'emploi, préférant entreprendre qu'administrer.*
 
-<img alt="Guillaume Houzel" src="https://github.com/betagouv/beta.gouv.fr/blob/master/img/authors/guillaume.houzel.jpg" width="150">
+<img alt="Guillaume Houzel" src="https://raw.githubusercontent.com/betagouv/beta.gouv.fr/master/img/authors/guillaume.houzel.jpg" width="150">


### PR DESCRIPTION
Fix du lien de l'image qui ne fonctionne pas via page publique : https://beta.gouv.fr/startups/apprentissage.html

Merci de contribuer au site de beta.gouv.fr ! 

🙂

Vous pouvez
- [ ] Effacez les lignes d'explications ci-dessus
- [ ] Expliquer les modifications pour faciliter la relecture
- [ ] Lancer un appel à review sur le channel #incubateur-site sur Slack
