### PR TITLE
Retrait du statut de la startup

### DIFF
--- a/content/_startups/jesaisfaire.md
+++ b/content/_startups/jesaisfaire.md
@@ -3,7 +3,7 @@ title: JeSaisFaire
 mission: Réconcilier acheteurs et PME avec les marchés publics.
 owner: Ministère de l'Intérieur
 incubator: lab-mi
-status: investigation
+status: 
 start: 2019-11-05
 end:
 link:


### PR DESCRIPTION
Dépublication provisoire de la fiche en attendant clarification.
Elle sera toujours accessible via l'URL mais pas visible sur la page /Startups

