### PR TITLE
Renomme le projet access4all en acceslibre.

### DIFF
--- a/content/_startups/acceslibre.md
+++ b/content/_startups/acceslibre.md
@@ -1,17 +1,19 @@
 ---
-title: Access4all
+title: Acceslibre
 mission: La plateforme collaborative pour l’accessibilité
 owner: Ministère de la Transition écologique et solidaire
 incubator: mtes
 status: construction
-link: https://access4all.beta.gouv.fr
-repository: https://github.com/MTES-MCT/access4all
+link: https://acceslibre.beta.gouv.fr
+repository: https://github.com/MTES-MCT/acceslibre
 contact: julia.zucker@developpement-durable.gouv.fr
 stats: true
 start: 2019-11-01
 product_launch_date: ""
 national_scale_date: ""
 end: null
+redirect_from:
+    - /startups/acces4all
 ---
 
 ## Le problème : Le manque d’information sur l’accessibilité des lieux


### PR DESCRIPTION
Bonjour,

Le site *access4all* est désormais rebaptisé *acceslibre*, et cette PR met à jour la fiche en conséquence. Merci !
