### PR TITLE
mise à jour statut et actualité transfert

### DIFF
--- a/content/_startups/zam.md
+++ b/content/_startups/zam.md
@@ -3,7 +3,7 @@ title: Zam
 mission: Alléger la charge de préparation par le gouvernement du débat parlementaire.
 owner: DINUM
 incubator: dinum
-status: partenariat passé
+status: transfert
 start: 2018-03-28
 end:
 link:

--- a/content/_startups/zam.md
+++ b/content/_startups/zam.md
@@ -3,7 +3,7 @@ title: Zam
 mission: Alléger la charge de préparation par le gouvernement du débat parlementaire.
 owner: DINUM
 incubator: dinum
-status: acceleration
+status: partenariat passé
 start: 2018-03-28
 end:
 link:
@@ -56,3 +56,7 @@ La solution numérique est expérimentée depuis le dernier trimestre 2018 sur d
 Sur l’année 2019, les expérimentations se poursuivent de même que les développements, guidés par les retours des testeurs ainsi que par les expertises métier des membres du groupe d’utilisateurs (passés, futurs et potentiels) qui a été formé.
 
 L'enjeu est désormais d'organiser la transition, souhaitée pour le début de l'année 2020, vers un fonctionnement en routine dans lequel Zam est l'outil gouvernemental de gestion des amendements, disponible pour toutes les administrations.
+
+## Le transfert
+
+Zam a été transféré par l'équipe startup d'Etat aux services du Premier ministre afin d'être généralisé au début de l'année 2020. Le Secrétariat général du Gouvernement et la DILA mettent désormais à la disposition de l'ensemble des ministères l'outil sous le nom de Signale. Pour plus d'information, contacter David Sarthou, reponsable de pôle au SGG à l'adresse david.sarthou@sgg.pm.gouv.fr


### PR DESCRIPTION
preneuse de feedback sur le changement de statut, je ne sais pas si ce que j'ai mis est correct ("partenariat passé" sur conseil d'Ishan mais quand je consulte ici https://beta.gouv.fr/approche/ je ne trouve pas de phase postérieure à "transfert", je sais que "abandon" existe mais ce n'est pas adapté pour ce cas là)