### PR TITLE
Tri communaute

### DIFF
--- a/_plugins/community.rb
+++ b/_plugins/community.rb
@@ -14,11 +14,8 @@ module Jekyll
         end
       end
 
-      if state == 'current'
-        current
-      else
-        past
-      end
+      result = if state == 'current' then current else past end
+      result.sort_by { |person| person.data['missions']&.map{ |e| e['start'] || Date.today }&.min || Date.today }.reverse
     end
   end
 

--- a/content/_authors/michael.machado.md
+++ b/content/_authors/michael.machado.md
@@ -2,6 +2,11 @@
 fullname: Michael Machado
 role: Ops
 github: mikinhas
+missions:
+  - start: 2020-01-15
+    end: 2020-04-15
+    status: service
+    employer: octo
 startups:
   - pass-culture
 ---

--- a/content/_authors/touraya.el_hassani.md
+++ b/content/_authors/touraya.el_hassani.md
@@ -1,11 +1,12 @@
 ---
 fullname: Touraya El Hassani
 role: Data Scientist
-github: tourayaeh
-missions: 
+missions:
   - start: 2020-01-13
     end: 2020-05-01
     status: service
     employer: octo
 startups:
     - pass-culture
+github: tourayaeh
+---


### PR DESCRIPTION
Rétablissement de l'ordre d'affichage des membres de la communauté par date d'arrivée (du plus récent au plus ancien).