### PR TITLE
Change l'ordre des tests pour accélérer les fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,11 +35,6 @@ jobs:
     - name: Check startup metadata
       run: ruby rb/bin/validate rb/schema/startups.yml "content/_startups/*.md"
       
-    - name: Install Pip
-      run: sudo apt-get install python3-pip python3-setuptools
-      
-    - name: Install html5validator
-      run: pip3 install --user --upgrade html5validator
     - name: "Check authors file name structure (first_name.last_name.md)"
       run: |
             if ls content/_authors | grep --line-regexp --invert-match '[a-z_-]\+\.[a-z_-]\+\.md'
@@ -54,6 +49,7 @@ jobs:
             EOF
               exit 1
             fi
+            
     - name: Check Jekyll configuration
       run: bundle exec jekyll doctor
 
@@ -65,6 +61,12 @@ jobs:
 
     - name: Check HTML common mistakes
       run: bundle exec htmlproofer ./_site --assume-extension --check-html --disable-external --empty-alt-ignore --check-img-http
+
+    - name: Install Pip
+      run: sudo apt-get install python3-pip python3-setuptools
+      
+    - name: Install html5validator
+      run: pip3 install --user --upgrade html5validator
 
     - name: Validate HTML spec compliance
       run: $HOME/.local/bin/html5validator --root _site --ignore 'Element "img" is missing required attribute "src"'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,16 @@ jobs:
           ${{ runner.os }}-gems-
     - name: Install dependencies
       run: bundle check || bundle install --path vendor/bundle
+    
+    - name: Check author metadata
+      run: ruby rb/bin/validate rb/schema/authors.yml "content/_authors/*.md"
+
+    - name: Check startup metadata
+      run: ruby rb/bin/validate rb/schema/startups.yml "content/_startups/*.md"
+      
     - name: Install Pip
       run: sudo apt-get install python3-pip python3-setuptools
+      
     - name: Install html5validator
       run: pip3 install --user --upgrade html5validator
     - name: "Check authors file name structure (first_name.last_name.md)"
@@ -60,12 +68,6 @@ jobs:
 
     - name: Validate HTML spec compliance
       run: $HOME/.local/bin/html5validator --root _site --ignore 'Element "img" is missing required attribute "src"'
-
-    - name: Check author metadata
-      run: ruby rb/bin/validate rb/schema/authors.yml "content/_authors/*.md"
-
-    - name: Check startup metadata
-      run: ruby rb/bin/validate rb/schema/startups.yml "content/_startups/*.md"
 
     - name: Lint JSON API pages
       run: bundle exec jsonlint _site/api/v*/*.json


### PR DESCRIPTION
Les erreurs de syntaxes dans le yaml sont les plus courantes, autant le tester le plus tôt possible pour donner un feedback rapide

- J'ai remonté les tests YAML
- J'ai descendu l'installation de html5validator juste au moment où on en a besoin

**Resultat attendu** : tous les tests avec erreurs devrait renvoyer un feedback beaucoup plus rapidement