### PR TITLE
Création fiche cyril cincet

### DIFF
--- a/content/_authors/cyril.cincet.md
+++ b/content/_authors/cyril.cincet.md
@@ -1,0 +1,14 @@
+---
+fullname: Cyril Cincet
+role: Coach
+missions:
+  - start: 2020-07-01
+    end: 2021-12-31
+    status: service
+    employer: octo
+startups :
+  - candilib
+  - psij
+---
+
+Coach startup à l'incubateur du LabMI

--- a/content/_authors/nicolas.boulio.md
+++ b/content/_authors/nicolas.boulio.md
@@ -3,7 +3,7 @@ fullname: Nicolas Boulio
 role: Coach
 missions:
   - start: 2019-09-01
-    end: 2020-08-31
+    end: 2020-07-10
     status: service
     employer: octo
 startups :


### PR DESCRIPTION
en remplacement de Nicolas Boulio à partir de juillet en coach sur le labMI sur Candilib et PSIJ