### PR TITLE
Fiche de poste pour un·e dev pour transport.data.gouv.fr

### DIFF
--- a/content/_jobs/2020-09-22-dev-transport.md
+++ b/content/_jobs/2020-09-22-dev-transport.md
@@ -1,0 +1,46 @@
+---
+roles: une / un développeuse, développeur
+startup: transport
+techno: Elixir (Phoenix) / Rust / Python
+open: true
+---
+
+La verticale transport de data.gouv.fr cherche une personne intéressée par les transports et les données ouvertes !
+
+<!--more-->
+
+Vous rejoindrez l’[équipe autonome](https://blog.beta.gouv.fr/general/2016/11/28/equipes-autonomes/) qui développe transport.data.gouv.fr.
+
+transport.beta.gouv.fr a pour objectif d’exposer toutes les données transport, de faciliter leur réutilisation, et ainsi d’aider les usagers des transports à mieux se déplacer.
+
+Nous cherchons une personne pour rejoindre notre équipe et nous aider à atteindre les objectifs suivants :
+
+1. Réunir un maximum d’utilisateurs autour de la plateforme de diffusion de données transport.
+2. Atteindre l’exhaustivité des données transport françaises référencées sur data.gouv.fr.
+3. Fournir des outils pour faciliter la réutilisation des données pour faciliter la réutilisation, la publication et la mise à jour des données.
+
+Il s’agit donc :
+
+- D’intervenir majoritairement sur une base ouverte de code en [Elixir](https://elixir-lang.org/)/[Phoenix](https://www.phoenixframework.org/) (le [site web](https://github.com/etalab/transport-site)) avec un peu de [Rust](https://www.rust-lang.org/) (le [validateur de données GTFS](https://github.com/etalab/transport-validator) et le [module de conversion de données temps-réel](https://github.com/etalab/transpo-rt/)) ainsi qu’un peu de [Python](https://www.python.org/) (pour [des outils périphériques](https://github.com/etalab/gtfs_converter/)).
+- De discuter avec des producteurs de données ainsi que des réutilisateurs, de comprendre leurs besoins, et de construire un service public de la donnée de transport.
+- Et de participer à la création de la communauté pour réussir ces objectifs.
+
+Nous cherchons à créer une équipe multidisciplinaire : pas besoin d’être expert·e de tous ces sujets, nous nous répartirons la charge selon les intérêts et expertises de chaque membre.
+
+
+## Compétences et expérience
+
+- Vous avez à cœur de rendre un service de qualité et avez toujours en tête l’utilisateur final lorsque vous travaillez.
+- Vous êtes autonome, et avez envie de vous impliquer dans l’auto-organisation de l’équipe et la coconstruction d’un produit.
+- Les problématiques autour des données de transport vous intéressent.
+
+## Modalités
+
+- Poste ouvert pour un·e indépendant·e (en portage).
+- Temps partiel et télétravail bienvenu.
+
+## Candidater
+
+Expliquez-nous pourquoi vous avez envie de nous rejoindre et envoyez-nous votre LinkedIn / CV et GitHub, le tout à `contact@transport.beta.gouv.fr`.
+
+À bientôt ! 😀


### PR DESCRIPTION
Ajout d'une offre d'emploi pour recruter une développeuse ou un développeur pour la startup transport.data.gouv.fr.