### PR TITLE
Fermeture fiche de poste - Chef·fe de produit intrapreneur·e de SignalConso

### DIFF
--- a/content/_jobs/2020-07-15-Chef·fe de produit intrapreneur·e de SignalConso.md
+++ b/content/_jobs/2020-07-15-Chef·fe de produit intrapreneur·e de SignalConso.md
@@ -2,7 +2,7 @@
 roles: Chef·fe de produit intrapreneur·e de SignalConso (DGCCRF)
 startup: signalement
 junior: false 
-open: true 
+open: false 
 title: Chef/cheffe de produit intrapreneur de SignalConso
 ---
 


### PR DESCRIPTION
Fermeture fiche de poste - Chef·fe de produit intrapreneur·e de SignalConso