### PR TITLE
Dépublie l'offre de mission pour Aides-territoires

### DIFF
--- a/content/_jobs/2020-07-24-devs-aides-territoires.md
+++ b/content/_jobs/2020-07-24-devs-aides-territoires.md
@@ -4,7 +4,7 @@ startup: aides-territoires
 techno: Django
 junior: true
 title: Aides-territoires recrute deux devs *full stack* en freelance
-open: true
+open: false
 ---
 
 **Un profil expérimenté, un profil junior.**


### PR DESCRIPTION
Je dépublie la fiche de mission pour Aides-territoires.

Raison : nous recevons beaucoup de candidatures avec des profils qui ne correspondent pas à nos attentes, et nous avons déjà un certain nombre de candidats en attente d'entretiens.

Au pire, on republiera une fiche un peu plus précise quand on aura reprécisé nos besoins.
