### PR TITLE
Retire "Anciennement Lapins" de la fiche RDV-Solidarités

### DIFF
--- a/content/_startups/lapins.md
+++ b/content/_startups/lapins.md
@@ -1,8 +1,8 @@
 ---
-title: RDV Solidarités (anciennement Lapins)
+title: RDV Solidarités
 mission: Réduire le nombre de rendez-vous annulés dans les maisons départementales de solidarité
 owner: Consortium de départements
-sponsors: 
+sponsors:
     - name: Fabrique des territoire
       acronym:
       domaine_ministeriel: territoires
@@ -14,15 +14,16 @@ phases:
   - name: construction
     start: 2018-01-18
   - name: acceleration
-link: https://rdv-solidarites.fr
+link: https://www.rdv-solidarites.fr
 repository: https://github.com/betagouv/rdv-solidarites.fr
-stats: false
+stats: true
+stats_url: https://www.rdv-solidarites.fr/stats/
 contact: contact@rdv-solidarites.fr
 ---
 
 ## Des milliers de lapins dans les Maisons départementales de solidarité !
 
-Chaque année, des dizaines de milliers de rendez-vous pris dans les maisons départementales de solidarité (MDS). Selon nos estimations réalisées dans plusieurs départements, près de 20 % en moyenne ne sont ni honorés, ni excusés : ce sont des lapins. A ces lapins s'ajoutent des rendez-vous annulés et non remplacés, portant la moyenne des rendez-vous vacants à près de 25%.
+Chaque année, des dizaines de milliers de rendez-vous sont pris dans les maisons départementales de solidarité (MDS). Selon nos estimations réalisées dans plusieurs départements, près de 20 % en moyenne ne sont ni honorés, ni excusés : ce sont des lapins. À ces lapins s'ajoutent des rendez-vous annulés et non remplacés, portant la moyenne des rendez-vous vacants à près de 25%.
 
 Le projet est né dans le Pas-de-Calais, sur proposition de deux travailleuses médico-sociales devenues intrapreneuses du projet. Pendant un an, l'équipe a cherché à caractériser le problème et ses causes et à expérimenter des solutions. Elle a trouvé les moyens de réduire le taux de lapins à un niveau inférieur à 5% sur les zones pilotes. 
 

--- a/content/_startups/lapins.md
+++ b/content/_startups/lapins.md
@@ -1,5 +1,5 @@
 ---
-title: RDV Solidarités
+title: RDV-Solidarités
 mission: Réduire le nombre de rendez-vous annulés dans les maisons départementales de solidarité
 owner: Consortium de départements
 sponsors:


### PR DESCRIPTION
en passant : 

- fix typo première phrase
- rajoute url stats