### PR TITLE
Ferme la recherche de dev pour transport.data.gouv.fr

### DIFF
--- a/content/_jobs/2020-09-22-dev-transport.md
+++ b/content/_jobs/2020-09-22-dev-transport.md
@@ -2,7 +2,7 @@
 roles: une / un développeuse, développeur
 startup: transport
 techno: Elixir (Phoenix) / Rust / Python
-open: true
+open: false
 ---
 
 La verticale transport de data.gouv.fr cherche une personne intéressée par les transports et les données ouvertes !


### PR DESCRIPTION
transport.data.gouv.fr a la chance d’accueillir https://github.com/thbar dans son équipe, on peut fermer l'offre.