### PR TITLE
Ancre équipe

### DIFF
--- a/_includes/grid-authors.html
+++ b/_includes/grid-authors.html
@@ -13,7 +13,7 @@
 {%- comment -%}<!-- On boucle sur les membres de l'équipe -->{%- endcomment -%}
 {%- assign team = site.authors | where:"startups", startup_id -%}
 
-{%- for author in team -%}      
+{%- for author in team -%}
   {%- capture to_append -%}
     {%- include card-community.html author=author -%}
   {%- endcapture -%}
@@ -33,14 +33,14 @@
 {%- comment -%}<!-- On boucle sur les anciens membres de l'équipe -->{%- endcomment -%}
 {%- assign startup_id = include.startup.id | remove: '/startups/' -%}
 {%- assign team_previous = site.authors | where:"previously", startup_id %}
-{%- for author in team_previous -%}      
+{%- for author in team_previous -%}
   {%- capture to_append -%}
     {%- include card-community.html author=author -%}
   {%- endcapture -%}
   {%- assign past_team = past_team | append: to_append -%}
 {%- endfor -%}
 
-<h2>L'équipe actuelle</h2>
+<h2 id="equipe">L'équipe actuelle</h2>
 <div class="grid">
   {{ current_team }}
 </div>

--- a/content/_authors/paul.chavard.md
+++ b/content/_authors/paul.chavard.md
@@ -9,6 +9,7 @@ missions:
     status: independent
 startups:
   - demarches-simplifiees.fr
+previously:
   - mon-entreprise
 ---
 

--- a/content/_startups/sanitaires-collegiens.md
+++ b/content/_startups/sanitaires-collegiens.md
@@ -47,5 +47,5 @@ Le moment pendant lequel ils sont le plus utilisés est la pause méridienne. Or
 ## Territoire d'expérimentation : 
 Département du Val d'Oise
 
-## Equipe
+## Équipe
 Juliette Pressé


### PR DESCRIPTION
Ajout d'une ancre pour pouvoir faire un lien direct vers la section « Équipe ».