### PR TITLE
Ajout d'une mission requise sur l'interface netlify cms pour la création d'une fiche membre

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -240,6 +240,7 @@ collections:
         hint: "Ton historique de missions avec nous dans l'ordre chronologique."
         name: 'missions'
         widget: 'list'
+        min: 1
         collapsed: false
         fields:
           - label: "Statut"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -241,7 +241,6 @@ collections:
         name: 'missions'
         widget: 'list'
         min: 1
-        max: 10
         collapsed: false
         fields:
           - label: "Statut"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -241,6 +241,7 @@ collections:
         name: 'missions'
         widget: 'list'
         min: 1
+        max: 10
         collapsed: false
         fields:
           - label: "Statut"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -241,6 +241,7 @@ collections:
         name: 'missions'
         widget: 'list'
         min: 1
+        max: 10 # both min and max are required to be apply 
         collapsed: false
         fields:
           - label: "Statut"


### PR DESCRIPTION
Certaines fiches arrivent de netlify sans missions donc les tests echouent, car l'interface netlify n'affiche pas d'erreur si le champ mission n'est pas rempli.
Avec le widget list, il faut définir un min ET un max dans le config file pour qu'un check soit fait.
J'ai donc rajouté min 1 et max 10, pour le max j'ai pris une valeur de manière totalement arbitraire. 
J'ai test sur https://deploy-preview-5056--beta-gouv-fr.netlify.app/admin/ et ça fonctionne.