### PR TITLE
Ne pas activer l'automerge si le secret n'est pas là

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"
-        if: "${{ GITHUB_TOKEN }}"
+        if: "${{ env.GITHUB_TOKEN }}"
         env:
           GITHUB_TOKEN: "${{ secrets.AUTOMERGE_ACTION_LUCAS_TEST_TOKEN }}"
           MERGE_LABELS: "merge it !"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"
-        # if: "${ secrets.AUTOMERGE_ACTION_TOKEN }"
+        if: "${ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }"
         env:
           # use default github token is AUTOMERGE_ACTION_TOKEN is not defined (on fork branch), but it won't rerun the tests
           GITHUB_TOKEN: "${ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"
-        if: ${{ secrets.AUTOMERGE_ACTION_LUCAS_TEST_TOKEN }}
+        if: "${{ secrets.AUTOMERGE_ACTION_LUCAS_TEST_TOKEN }}"
         env:
           GITHUB_TOKEN: "${{ secrets.AUTOMERGE_ACTION_LUCAS_TEST_TOKEN }}"
           MERGE_LABELS: "merge it !"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,9 +23,9 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"
-        if: "${{ env.GITHUB_TOKEN }}"
+        if: "${{ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }}"
         env:
-          GITHUB_TOKEN: "${{ secrets.AUTOMERGE_ACTION_LUCAS_TEST_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "merge it !"
           MERGE_REMOVE_LABELS: "merge it !"
           UPDATE_LABELS: "merge it !"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"
-        if: "${{ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }}"
+        # if: "${{ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }}"
         env:
           # use default github token is AUTOMERGE_ACTION_TOKEN is not defined (on fork branch), but it won't rerun the tests
           GITHUB_TOKEN: "${ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"
+        if: ${{ secrets.AUTOMERGE_ACTION_LUCAS_TEST_TOKEN }}
         env:
           GITHUB_TOKEN: "${{ secrets.AUTOMERGE_ACTION_LUCAS_TEST_TOKEN }}"
           MERGE_LABELS: "merge it !"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,8 +23,9 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"
-        if: "${ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }"
+        # if: "${ secrets.AUTOMERGE_ACTION_TOKEN }"
         env:
+          # use default github token is AUTOMERGE_ACTION_TOKEN is not defined (on fork branch), but it won't rerun the tests
           GITHUB_TOKEN: "${ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }"
           MERGE_LABELS: "merge it !"
           MERGE_REMOVE_LABELS: "merge it !"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"
-        if: "${{ secrets.AUTOMERGE_ACTION_LUCAS_TEST_TOKEN }}"
+        if: "${{ GITHUB_TOKEN }}"
         env:
           GITHUB_TOKEN: "${{ secrets.AUTOMERGE_ACTION_LUCAS_TEST_TOKEN }}"
           MERGE_LABELS: "merge it !"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"
-        if: "${ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }"
+        if: "${{ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }}"
         env:
           # use default github token is AUTOMERGE_ACTION_TOKEN is not defined (on fork branch), but it won't rerun the tests
           GITHUB_TOKEN: "${ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,9 +23,9 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"
-        if: "${{ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }}"
+        if: "${ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }"
         env:
-          GITHUB_TOKEN: "${{ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }"
           MERGE_LABELS: "merge it !"
           MERGE_REMOVE_LABELS: "merge it !"
           UPDATE_LABELS: "merge it !"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,7 +26,7 @@ jobs:
         # if: "${{ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }}"
         env:
           # use default github token is AUTOMERGE_ACTION_TOKEN is not defined (on fork branch), but it won't rerun the tests
-          GITHUB_TOKEN: "${ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }"
+          GITHUB_TOKEN: "${{ secrets.AUTOMERGE_ACTION_TOKEN || secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "merge it !"
           MERGE_REMOVE_LABELS: "merge it !"
           UPDATE_LABELS: "merge it !"


### PR DESCRIPTION
🙂

A voir si ça marche avec les PR de fork (pour l'instant ça génére des erreurs sur les PR venant de fork)