### PR TITLE
Correction du lien vers la page statistiques de Pix

### DIFF
--- a/content/_startups/pix.md
+++ b/content/_startups/pix.md
@@ -20,6 +20,7 @@ phases:
 link: https://pix.fr
 repository: https://github.com/1024pix/pix/
 stats: true
+stats_url: https://pix.fr/statistiques
 contact: contact@pix.fr
 ---
 


### PR DESCRIPTION
Sur la page de présentation de la startup d'État Pix, l'url par défaut (https://pix.fr/stats) ne fonctionne pas. J'ai ajouté l'adresse correcte de la page (https://pix.fr/statistiques/).

Pour la review :
- [x] Les tests passent (avec un check vert)
