### PR TITLE
Replace mission Trajectoire Enfance

### DIFF
--- a/content/_startups/centre-departemental-enfance.md
+++ b/content/_startups/centre-departemental-enfance.md
@@ -1,6 +1,6 @@
 ---
 title: Trajectoire Enfance
-mission: Réduire le délai moyen d'attribution de l'allocation personnalisée d'autonomie
+mission: Permettre une meilleure prise en charge des enfants placés
 owner: Département du Var
 incubator: anct
 phases:


### PR DESCRIPTION
La "mission" semblait plutôt être celle de "Plateforme numérique direct autonomie".