### PR TITLE
Ajout du bon lien pour la page stat

### DIFF
--- a/content/_startups/locatio.md
+++ b/content/_startups/locatio.md
@@ -17,6 +17,7 @@ phases:
 link: https://dossierfacile.fr/?utm_source=betagouv
 repository: https://github.com/mtes-mct/locatio
 stats: true
+stats_url: https://dossierfacile.fr/stats
 contact: contact@dossierfacile.fr
 ---
 ## Locatio devient DossierFacile.fr !


### PR DESCRIPTION
J'ai ajouté le bon lien pour la page stat.
Le lien actuellement sur le site ne renvoi pas vers la page stat.