### PR TITLE
Supprime l’adresse de contact de Zam qui n’est plus valide

### DIFF
--- a/content/_startups/zam.md
+++ b/content/_startups/zam.md
@@ -19,7 +19,7 @@ phases:
 link:
 repository: https://github.com/betagouv/zam
 stats: false
-contact: contact@zam.beta.gouv.fr
+contact: contact@beta.gouv.fr
 techno:
     - Python
     - PostgreSQL


### PR DESCRIPTION
Remplace par l’adresse de contact générique, sachant que le lien généré inclura une mention de la page de la startup dans l’objet.