### PR TITLE
Fix link to the Classe à 12 website

### DIFF
--- a/content/_startups/classes12.md
+++ b/content/_startups/classes12.md
@@ -14,7 +14,7 @@ phases:
   - name: construction
     start: 2018-06-01
   - name: acceleration
-link: http://classea12.beta.gouv.fr/
+link: https://classe-a-12.beta.gouv.fr/
 repository: https://github.com/betagouv/ClasseA12
 stats: false
 contact: classea12@education.gouv.fr


### PR DESCRIPTION
Le nom de domaine a changé de classea12.beta.gouv.fr à classe-a-12.beta.gouv.fr, meilleur pour le SEO