### PR TITLE
Rename classes12.md to classe-a-12.md

### DIFF
--- a/content/_authors/aymeric.faivre.md
+++ b/content/_authors/aymeric.faivre.md
@@ -15,7 +15,7 @@ missions:
     status: independent
     employer: La Zone
 startups:
-  - classes12
+  - classe-a-12
 previously:
   - mon-entreprise
 ---

--- a/content/_authors/jean-philippe.poisson.md
+++ b/content/_authors/jean-philippe.poisson.md
@@ -8,5 +8,5 @@ missions:
     end:  2019-01-15
     status: independent
 startups:
-  - classes12
+  - classe-a-12
 ---

--- a/content/_authors/jeremie.cook.md
+++ b/content/_authors/jeremie.cook.md
@@ -12,7 +12,7 @@ missions:
     end: 2021-12-31    
     status: independent
 startups:
-  - classes12
+  - classe-a-12
   - ozensemble
   - monsuivipsy
   - preuve-de-covoiturage

--- a/content/_authors/malika.alouani.md
+++ b/content/_authors/malika.alouani.md
@@ -8,5 +8,5 @@ missions:
     status: admin
     employer: Education Nationale
 startups:
-  - classes12
+  - classe-a-12
 ---

--- a/content/_authors/mathieu.agopian.md
+++ b/content/_authors/mathieu.agopian.md
@@ -14,9 +14,9 @@ missions:
     start: 2019-10-01
     end: 2022-01-07
 previously:
-  - classes12
   - saisissez au vol
 startups:
+  - classe-a-12
   - egapro
 ---
 

--- a/content/_authors/nicolas.leyri.md
+++ b/content/_authors/nicolas.leyri.md
@@ -8,5 +8,5 @@ missions:
     status: admin
     employer: Académie de Créteil
 startups:
-  - classes12
+  - classe-a-12
 ---

--- a/content/_authors/vincent.agnano.md
+++ b/content/_authors/vincent.agnano.md
@@ -13,7 +13,7 @@ missions:
 startups:
   - egalite.professionnelle
 previously:
-  - classes12
+  - classe-a-12
   - saisissezauvol
   - eac
   - api-drones

--- a/content/_authors/yohan.boniface.md
+++ b/content/_authors/yohan.boniface.md
@@ -16,5 +16,5 @@ previously:
   - ban
   - api-drones
   - la-bonne-formation
-  - classes12
+  - classe-a-12
 ---

--- a/content/_jobs/2018-08-29-classes12-dev.md
+++ b/content/_jobs/2018-08-29-classes12-dev.md
@@ -1,6 +1,6 @@
 ---
 roles: un·e développeur·se web full stack
-startup: classes12
+startup: classe-a-12
 open: false
 ---
  

--- a/content/_startups/classe-a-12.md
+++ b/content/_startups/classe-a-12.md
@@ -1,5 +1,5 @@
 ---
-title: Classes à 12
+title: Classe à 12
 mission: Faciliter le passage en classe à 12 pour les enseignants et maximiser la valeur de ce dispositif pour les élèves.
 owner: Ministère de l'Éducation nationale
 sponsors: 
@@ -18,6 +18,8 @@ link: https://classe-a-12.beta.gouv.fr/
 repository: https://github.com/betagouv/ClasseA12
 stats: false
 contact: classea12@education.gouv.fr
+redirect_from:
+  - /startups/classes12.md
 ---
 # Le problème :
 En sept 2017, Le dispositif classe à 12 initié par le Ministère de l'éducation nationale a permis à plus de 2500 enseignants de se lancer dans l'expérimentation d'une classe à effectif réduit afin de favoriser la réussite des élèves en  éducation prioritaire.


### PR DESCRIPTION
Le nom de domaine/id de la startup est `classe-a-12.beta.gouv.fr`, donc il fallait renommer la fiche produit.
J'ai rajouté le `redirect_from` sur les conseils de @jdauphant 🙏 