### PR TITLE
Corrige le slug des fiches de job et désactive le bouton de publication

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -388,6 +388,9 @@ collections:
     folder: "content/_jobs"
     create: true
     delete: false
+    summary: {{roles}}
+    slug: "{{year}}-{{month}}-{{day}}_{{slug}}"
+    publish: false
     editor:
       preview: false
     fields:
@@ -407,7 +410,7 @@ collections:
         name: date
         widget: datetime
         time_format: false
-        required: true 
+        hint: "Uniquement si vous publiez la fiche plus tard"
       - label: Pour quelle startup ?
         label_singular: Startup
         hint: "Si la startup n'apparait pas encore dans la liste, contacte un administrateur du site !"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -394,7 +394,7 @@ collections:
     create: true
     delete: false
     summary: "{{roles}}"
-    slug: "{{year}}-{{month}}-{{day}}_{{slug}}"
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     publish: false
     editor:
       preview: false

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -51,6 +51,7 @@ collections:
   - name: startups
     publish: false
     label: Produits
+    preview_path: "startups/{{slug}}"
     label_singular: Produit
     folder: "content/_startups"
     create: true

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -48,6 +48,7 @@ date_field_defaults: &date_field_defaults
 
 collections:
   - name: startups
+    publish: false
     label: Produits
     label_singular: Produit
     folder: "content/_startups"
@@ -207,12 +208,13 @@ collections:
           Comment vous vous y prenez pour atteindre votre usagers ? quel impact chiffré visez-vous ?
       
   - name: "authors"
+    publish: false
     identifier_field: fullname
     label: "Membres"
     label_singular: "Membre"
     description: "Les membres de la communauté beta.gouv.fr. Pour modifier une fiche, clique sur son nom ou recherche-la dans la barre de gauche. Pour ajouter un nouveau membre, direction \"Créer une entrée de type Membre\" !"
     folder: "content/_authors"
-    create: true
+    create: false
     delete: false
     slug: "{{slug}}"
     editor:
@@ -336,6 +338,7 @@ collections:
           "Administration Publique"
         ]
   - name: incubators
+    publish: false
     label: Incubateurs
     label_singular: Incubateur
     folder: "content/_incubators"
@@ -362,6 +365,7 @@ collections:
     label_singular: Phase
     folder: "content/_phases"
     delete: false
+    publish: false
     slug: "{{slug}}"
     editor:
       preview: false
@@ -372,6 +376,7 @@ collections:
       - { label: order, name: order, widget: number }
       - { label: short_description, name: short_description, widget: string }
   - name: events
+    publish: false
     label: Évènement de SET
     label_singular: Évènement
     folder: "content/_events"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -214,7 +214,7 @@ collections:
     identifier_field: fullname
     label: "Membres"
     label_singular: "Membre"
-    description: "Les membres de la communauté beta.gouv.fr. Pour modifier une fiche, clique sur son nom ou recherche-la dans la barre de gauche. Pour ajouter un nouveau membre, direction \"Créer une entrée de type Membre\" !"
+    description: "Les membres de la communauté beta.gouv.fr. Pour modifier une fiche, clique sur son nom ou recherche-la dans la barre de gauche. Pour ajouter un nouveau membre, allez sur le secretariat : https://secretariat.incubateur.net/onboarding .
     folder: "content/_authors"
     create: false
     delete: false

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -12,6 +12,7 @@ backend:
     deleteMedia: Suppression de l'image {{path}}
   squash_merges: true
   open_authoring: true
+  use_graphql: true
 
 # Permet d'expérimenter en local
 # cf. https://www.netlifycms.org/docs/beta-features/#working-with-a-local-git-repository

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -388,7 +388,7 @@ collections:
     folder: "content/_jobs"
     create: true
     delete: false
-    summary: {{roles}}
+    summary: "{{roles}}"
     slug: "{{year}}-{{month}}-{{day}}_{{slug}}"
     publish: false
     editor:

--- a/admin/index.html
+++ b/admin/index.html
@@ -33,10 +33,6 @@
       display: none;
     }
 
-    div[class*="ToolbarSubSectionFirst-ToolbarSubSectionLast"] {
-      display: none;
-    }
-
     button[class*="ToolbarButton-button-default-buttonMargin-noOverflow-DeleteButton-lightRed"] {
       display: none;
     }

--- a/admin/index.html
+++ b/admin/index.html
@@ -132,7 +132,8 @@
             Après t'être connecté via Github, tu pourras :  </br><small>(si tu n'as pas de compte github tu peux voir la <a target="_blank" style="text-decoration: underline" href="https://doc.incubateur.net/communaute/outils/github">doc</a> pour t'en créer un)</small></br></br>
             <ul>
               <li>ajouter ou éditer une fiche produit</li>
-              <li>ajouter ou éditer une fiche membre</li>
+              <li>éditer une fiche membre</li>
+              <li>ajouter ou éditer une fiche de recrutement</li>
             </ul>
           </p>`
           onTheFlyAuthenticationElem.className = "onTheFlyAuthentificationElem";


### PR DESCRIPTION
🙂

- Correction de la date dans le slug des fiches de poste
- Ajout de "publish: false" qui enléve le bouton de publication (+ nettoyage de l'ancien code de suppression)
- Retire l'ajout de membre on devrait plutôt passer par le secretariat
- Toute l'interface sera plus rapide avec "use_graphql: true"