### PR TITLE
Met a jour offre d'emploi

### DIFF
--- a/content/_jobs/2021-05-05-partaj-charge-de-deploiement.md
+++ b/content/_jobs/2021-05-05-partaj-charge-de-deploiement.md
@@ -50,7 +50,7 @@ Poste ouvert pour un(e) indépendant(e) à pourvoir pour un contrat d’environ 
 
 Réunions d'équipe régulières en format visio. Des réunions en présentiel occasionnelles à prévoir sur Paris lorsque cela sera de nouveau envisageable.
 
-Démarrage à partir d’avril 2021.
+Démarrage dès que possible.
 
 ## Postuler
 


### PR DESCRIPTION
Le poste de chargé de déploiement chez Partaj est toujours ouvert.

Mise à jour de la date de début et de la date d'ouverture du poste pour que les candidat.e.s ne n'aient pas l'impression que l'offre est obsolète.
