### PR TITLE
Renomme l'Acoss en Urssaf Caisse nationale

### DIFF
--- a/content/_startups/mon-entreprise.md
+++ b/content/_startups/mon-entreprise.md
@@ -1,10 +1,10 @@
 ---
 title: Mon-entreprise.fr
-mission: "L'assistant officiel du créateur d'entreprise"
-owner: Acoss
+mission: "L’assistant officiel du créateur d’entreprise"
+owner: Urssaf
 sponsors:
-    - name: ACOSS
-      acronym: ACOSS
+    - name: Urssaf Caisse nationale
+      acronym: Urssaf
       domaine_ministeriel: affaires-sociales
       type: securite-sociale
 incubator: dinum
@@ -43,13 +43,13 @@ Et cette seconde étape a de quoi faire oublier la première ! Tout d'abord, vie
 - Les différences de fonctionnement du recouvrement des cotisations sociales entre indépendant et assimilé salarié
 - Estimer les cotisations pour l'établissement du budget prévisionnel
 
-Une fois l'entreprise lancée, les échéances fiscales et comptables rythment l'année. Parmis elles : la TVA, le bilan annuel, les cotisations sociales, la CFE, la taxe d'apprentissage, la contribution à la formation professionnelle.
+Une fois l'entreprise lancée, les échéances fiscales et comptables rythment l'année. Parmi elles : la TVA, le bilan annuel, les cotisations sociales, la CFE, la taxe d'apprentissage, la contribution à la formation professionnelle.
 
 Si le créateur s'en est sorti, il pourra alors embaucher et découvrir le prochain épisode des contraintes légales.
 
 Résultat : **créer une entreprise sans formation préalable ou accompagnement relève d'un véritable parcours du combattant**. L'information disponible est éclatée sur les sites institutionnels des différents acteurs, et souvent présentée sous la forme de longs paragraphes décontextualisés de la situation de l'entrepreneur.
 
-Or on observe une nette croissance du nombre d'entreprises crées en France (+18,5% sur les douze derniers mois). Cela s'explique nottament par le développement de l'économie collaborative (phénomène désigné par "l'uberisation de l'économie"), qui dans de nombreux cas impose la création d'une entreprise.
+Or on observe une nette croissance du nombre d'entreprises crées en France (+18,5% sur les douze derniers mois). Cela s'explique notamment par le développement de l'économie collaborative (phénomène désigné par "l'uberisation de l'économie"), qui dans de nombreux cas impose la création d'une entreprise.
 
 **Il devient donc urgent d'accompagner ces nouveaux dirigeants dans la création de leur entreprise à travers un parcours simple et personnalisé**
 
@@ -62,7 +62,7 @@ Nos cibles sont en particulier :
 - le citoyen qui se demande s'il faut et comment déclarer ses revenus de l'économie collaborative (livreur à vélo; VTC; loueur sur AirBnB; partage de voiture entre particuliers...)
 - Et plus généralement, le créateur d'entreprise qui découvre tout ce monde
 
-Mon-entreprise.fr est développé en étroite collaboration avec le réseau des URSSAF, et tous les acteurs institutionnels qui se montrerons intéressés.
+Mon-entreprise.fr est développé en étroite collaboration avec le réseau des Urssaf, et tous les acteurs institutionnels qui se montreront intéressés.
 
 ### Budget 💶
 
@@ -74,8 +74,8 @@ Le service est également disponible en anglais à l'adresse [mycompanyinfrance.
 
 ### Technologie 💻
 
-Tous les simulateurs et formulaires interactifs de mon-entreprise sont basé sur le moteur de calcul [publicodes](https://publi.codes), publié en open-source et réutilisable par tous.
+Tous les simulateurs et formulaires interactifs de mon-entreprise sont basés sur le moteur de calcul [publicodes](https://publi.codes), publié en open-source et réutilisable par tous.
 
-### Transfert à l'ACOSS
+### Transfert à l’Urssaf
 
-En 2020, le service et l'équipe Mon Entreprise sont transférés hors de l'incubateur de la DINUM vers l'ACOSS. 
+En 2020, le service et l'équipe Mon Entreprise sont transférés hors de l'incubateur de la DINUM vers l’Urssaf Caisse nationale. 


### PR DESCRIPTION
cf. https://www.acoss.fr/home/journalistes/communiques-de-presse/ListeCommuniquesPresse/lacoss-devient-urssaf-caisse-nat.html
