### PR TITLE
Encourager l'ouverture des budgets

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -52,6 +52,8 @@ Le code source
 {% capture budget_info %}
 {% if page.budget_url %}
 Le budget <a href="{{ page.budget_url }}">est ouvert</a>.
+{% else %}
+L’équipe ne communique pas encore sur son budget.
 {% endif %}
 {% endcapture %}
 
@@ -68,9 +70,7 @@ Technologies utilisées : {{ page.techno | join: ", " }}
     {% unless phase.status == 'investigation' %}
       <li>{{ statistiques_info }}</li>
       <li>{{ source_info }}</li>
-      {% if page.budget_url %}
       <li>{{ budget_info }}</li>
-      {% endif %}
       {% if page.techno %}
       <li>{{ techno_info }}</li>
       {% endif %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -34,7 +34,7 @@ L'équipe est portée par {{ page.owner }} dans <a href="/startups/?incubateur={
 {% capture statistiques_info %}
 Les statistiques d'usage
 {% if page.stats %}
-  <a href="{% if page.stats_url %}{{ page.stats_url }}{% else %}{{ page.link | strip }}/stats{% endif %}" title="Statistiques de {{ page.title }}">sont disponibles.</a>
+  <a href="{% if page.stats_url %}{{ page.stats_url }}{% else %}{{ page.link | strip }}/stats{% endif %}" title="Statistiques de {{ page.title }}">sont disponibles</a>.
 {% else %}
   <em>ne sont pas encore disponibles.</em>
 {% endif %}
@@ -43,9 +43,15 @@ Les statistiques d'usage
 {% capture source_info %}
 Le code source
 {% if page.repository %}
-  <a href="{{ page.repository }}">est libre.</a>
+  <a href="{{ page.repository }}">est libre</a>.
 {% else %}
   <em>n'est pas encore ouvert.</em>
+{% endif %}
+{% endcapture %}
+
+{% capture budget_info %}
+{% if page.budget_url %}
+Le budget <a href="{{ page.budget_url }}">est ouvert</a>.
 {% endif %}
 {% endcapture %}
 
@@ -62,6 +68,9 @@ Technologies utilisées : {{ page.techno | join: ", " }}
     {% unless phase.status == 'investigation' %}
       <li>{{ statistiques_info }}</li>
       <li>{{ source_info }}</li>
+      {% if page.budget_url %}
+      <li>{{ budget_info }}</li>
+      {% endif %}
       {% if page.techno %}
       <li>{{ techno_info }}</li>
       {% endif %}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -140,6 +140,10 @@ collections:
         name: stats
         widget: boolean
         required: false
+      - label: Lien vers la page budget
+        name: budget_url
+        widget: string
+        required: false
       - label: Évènements marquants
         name: events
         label_singular: évènement marquant

--- a/content/_startups/mon-entreprise.md
+++ b/content/_startups/mon-entreprise.md
@@ -24,6 +24,7 @@ events:
     date: 2020-03-01
 link: https://mon-entreprise.fr
 repository: https://github.com/betagouv/mon-entreprise
+budget_url: https://mon-entreprise.fr/budget
 stats: true
 contact: contact@mon-entreprise.beta.gouv.fr
 ---
@@ -63,10 +64,6 @@ Nos cibles sont en particulier :
 - Et plus généralement, le créateur d'entreprise qui découvre tout ce monde
 
 Mon-entreprise.fr est développé en étroite collaboration avec le réseau des Urssaf, et tous les acteurs institutionnels qui se montreront intéressés.
-
-### Budget 💶
-
-👉 [Consulter la description détaillée et atualisée](https://mon-entreprise.fr/budget)
 
 ### Internationalisation 🌍
 

--- a/rb/schema/startups.yml
+++ b/rb/schema/startups.yml
@@ -85,6 +85,8 @@ mapping:
     type:      bool
   "stats_url":
     type:      str
+  "budget_url":
+    type:      str
   "contact":
     type:      str
     pattern:   /@/


### PR DESCRIPTION
Les services beta.gouv sont financés par de l'argent public, il me paraît donc important d'être transparents sur les montants alloués à chaque produit et sur la manière dont ils sont employés.

Il y avait eu une tentative d'intégrer cette information dans #3088, mais elle avait été abandonnée par manque de données des startups. Plutôt que d'essayer de normaliser les données et de les afficher directement sur beta.gouv.fr, on peut encourager les équipes à créer une page `/budget` sur le modèle de ce que l'on fait déjà pour la page `/stats`.

Démo : https://deploy-preview-6118--beta-gouv-fr.netlify.app/startups/mon-entreprise.html

À noter que les conventions de partenariat avec la DINUM sont déjà en open-data sur https://www.data.gouv.fr/fr/datasets/conventions-de-partenariat/, les équipes concernées peuvent donc faire un lien vers ces documents.

Prochaines étapes :
- Créer une page « Publier son budget » dans la documentation de l'incubateur https://github.com/betagouv/doc.incubateur.net-communaute/pull/41
- Organiser un atelier pour identifier les bonnes pratiques (montants avec ou sans TVA, affichage du markup de l'attributaire, granularité des dépenses, etc.)
- Contacter les startups pour les encourager à publier leur budget