### PR TITLE
Ajout du profil Marion Paclot

### DIFF
--- a/content/_authors/marion.paclot.md
+++ b/content/_authors/marion.paclot.md
@@ -1,0 +1,14 @@
+---
+fullname: Marion Paclot
+role: Data Scientist
+domaine: Développement
+link: https://github.com/marion-paclot
+github: marion-paclot
+missions:
+  - start: 2021-06-01
+    end: 2022-06-01
+    status: independent
+    employer: Octo
+startups:
+  - carbure
+---


### PR DESCRIPTION
Marion Paclot ex data.gouv.fr rejoint CarbuRe en tant que Data Scientist freelance (via Octo)
