### PR TITLE
Fix link to publicodes library on npmjs

### DIFF
--- a/content/_jobs/2021-05-25-mon-entreprise-fr.recrute.js.md
+++ b/content/_jobs/2021-05-25-mon-entreprise-fr.recrute.js.md
@@ -50,8 +50,8 @@ Notre façon de travailler est très horizontale et fait la part belle à l'auto
 * prendre des vacances à n'importe quel moment
 * proposer un nouveau simulateur
 * ouvrir / fermer des [issues](https://github.com/betagouv/mon-entreprise/issues)
-* publier la [bibliothèque NPM](https://https://github.com/betagouv/publicodes)
-* ajouter un [dispositif legislatif](https://github.com/betagouv/mon-entreprise/issues/714) 
+* publier la [bibliothèque publicodes sur le registre npm](https://www.npmjs.com/package/publicodes)
+* ajouter un [dispositif législatif](https://github.com/betagouv/mon-entreprise/issues/714) 
 * organiser des sessions de tests utilisateurs
 
 ## Candidater 💌


### PR DESCRIPTION
- Fix a small typo (double https protocol) in the link
- Clarify the label + fix the [spelling of npm](https://twitter.com/seldo/status/850042251635867648)
🙂
