### PR TITLE
add sendinblue link to signup form

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -208,21 +208,11 @@ layout: default
 <hr>
 <section class="fr-py-6w newsletter">
   <div class="fr-container">
-    <form method="post" action="https://app.mailjet.com/widget/iframe/1O2v/9ud" id="newsletter">
+    <form method="post" target="_blank" action="https://981c5932.sibforms.com/serve/MUIEAED7q5La6zVwcMrAI5cwJB2EZmeOZVHfadIeHA7u9YyGUb9FB0MqprJ1A4DbWnpORGiPSZA4yxdpLFnWbjSvsFFgYNTtd7A54LhPxK3Zg2jaB_qK-b5Sm6aZ2M6kV1nO2mpJW0KcFGIMb5KbirWUxg8CJsQJUp_AJ6ARN5PSdFNxQpzVAPXKMNs1Z7n9lgK9bMoL9fFVP_Wx" id="newsletter">
       <h4>Gardons le contact</h4>
       <p>Recevez les actualités de beta.gouv, tous les mois</p>
-
-      <input type="hidden" id="csrf_token" name="csrf_token" value="MmE2NTZkNWQ0MGQ0Y2IzOWQyZTllOWUxZGI2OWJhMTM2OTJhMDRjNzJjYjM5NWQ4MTRkM2UwNmRlYzBjM2RiYg==">
       <div class="fr-input-group">
-        <input required=""
-          class="fr-input"
-          type="email"
-          autocomplete="on"
-          id="subscribe-email"
-          name="w-field-field-36469-172104-430683-email"
-          placeholder="votre adresse e-mail" />
         <button class="fr-btn" type="submit" name="subscribe" id="form-submit">S’inscrire</button>
-
       </div>
     </form>
   </div>


### PR DESCRIPTION
On avait toujours l'ancien signup mailjet, alors qu'on envoi nos NL depuis sendinblue ...

<img width="515" alt="Capture d’écran 2021-06-16 à 11 48 54" src="https://user-images.githubusercontent.com/3593868/122197823-de9b4280-ce98-11eb-8cca-a5a07d1bf2c4.png">
<img width="548" alt="Capture d’écran 2021-06-16 à 11 49 01" src="https://user-images.githubusercontent.com/3593868/122197838-e0fd9c80-ce98-11eb-9ccd-b82e5f25238a.png">
