### PR TITLE
Mise à jour des données de la startup Ideaule / EnvErgo

### DIFF
--- a/content/_authors/adrien.plantureux.md
+++ b/content/_authors/adrien.plantureux.md
@@ -9,7 +9,7 @@ missions:
     status: admin
     employer: MTE
 startups:
-  - ideaule
+  - envergo
 competences:
   - Administration Publique
 ---

--- a/content/_authors/nicolas.enjalbert.md
+++ b/content/_authors/nicolas.enjalbert.md
@@ -12,6 +12,6 @@ competences:
   - Coaching
 role: Coach investigation & construction produit
 startups:
-  - ideaule
+  - envergo
 ---
 Designer de services & coach produit, fan de visualisation de données, engagé bénévole pour un design plus responsable

--- a/content/_authors/thibault.jouannic.md
+++ b/content/_authors/thibault.jouannic.md
@@ -6,10 +6,11 @@ link: https://www.miximum.fr
 github: thibault
 missions:
   - start: 2018-08-01
-    end: 2021-06-30
+    end: 2021-12-31
     status: independent
 startups:
     - aides-territoires
+    - envergo
 ---
 
 A choisi de devenir développeur pour changer le monde sans bouger de son fauteuil.

--- a/content/_startups/envergo.md
+++ b/content/_startups/envergo.md
@@ -1,5 +1,5 @@
 ---
-title: Ideaule
+title: EnvErgo
 mission: Améliorer la transparence des décisions de l'État sur la Loi sur l'Eau
 owner: Direction générale de l'aménagement, du logement et de la nature (DGALN)
 sponsors:
@@ -37,7 +37,7 @@ L’Etat publie ses décisions administratives environnementales prises au titre
 
 Le public (association, usagers, socio-professionnels, collectivités) concerné par ces projets ne peut pas bénéficier d’une telle vision partagée. Cette situation engendre : 
 
-* une connaissance peu mobilisable, qui coûte en temps à ré-utiliser ou reproduire à chaque nouveau projet 
+* une connaissance peu mobilisable, qui coûte en temps à ré-utiliser ou reproduire à chaque nouveau projet
 * une difficulté à connaître et accéder dans le temps aux actes, et à leur contenu.
 
 


### PR DESCRIPTION
La startup Ideaule change de nom et devient EnvErgo.

Je me suis ajouté en tant que dev sur la fiche produit.

 * rename Ideaule to EnvErgo
 * Add Thibault to the product
