### PR TITLE
Fix sort order in jobs list

### DIFF
--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -11,7 +11,7 @@ layout: default
     <div class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col-md-9 fr-col-sm-12 fr-col-lg-9">
         <div class="fr-grid-row">
-          {% assign jobs = site.jobs | where: "open", 'true' | reverse %}
+          {% assign jobs = site.jobs | where: "open", 'true' |  sort: "date", "last" %}
           {% for job in jobs %}
             {% assign startup_id = job.startup %}
             {% assign startup = site.startups | where: "title", startup_id | first %}

--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -11,7 +11,7 @@ layout: default
     <div class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col-md-9 fr-col-sm-12 fr-col-lg-9">
         <div class="fr-grid-row">
-          {% assign jobs = site.jobs | where: "open", 'true' |  sort: "date", "last" %}
+          {% assign jobs = site.jobs | where: "open", 'true' |  sort: "date" | reverse %}
           {% for job in jobs %}
             {% assign startup_id = job.startup %}
             {% assign startup = site.startups | where: "title", startup_id | first %}


### PR DESCRIPTION
Il y a un souci de tri des offres de recrutement par date.
Je pense que ca vient du fait que certains fichiers MD ont un attribut YML `date` et d'autres n'en ont pas - auquel cas la date du prefix du nom de fichier est utilisée. Le tri par defaut se fait toujours sur base du nom de fichier, tandis que l'affichage se fait sur base de l'attribut si present avec fallback vers le prefixe du nom de fichier.

je corrige en harmonisant le tri fait avec l'affichage

# Avant

<img width="655" alt="Screen Shot 2021-08-24 at 10 49 41" src="https://user-images.githubusercontent.com/883348/130587211-18963e58-9e8c-4533-9a31-17491d26f4b8.png">

# Apres

<img width="682" alt="Screen Shot 2021-08-24 at 11 05 42" src="https://user-images.githubusercontent.com/883348/130589611-350ad644-2601-4970-8f73-e38432368792.png">
