### PR TITLE
remove parenthesis and double pipe in card-job

### DIFF
--- a/_includes/card-job.html
+++ b/_includes/card-job.html
@@ -19,7 +19,7 @@
     <div>
       <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col">
-          <p class="fr-card__detail">Offre de {% if job.friend %}{{ job.friend | strip_html }}{% else %}{{ (startup.title || job.startup) | default: "beta.gouv.fr" | strip_html}}{% endif %}</p>
+          <p class="fr-card__detail">Offre de {% if job.friend %}{{ job.friend | strip_html }}{% else %}{{ startup.title | default: "beta.gouv.fr" | strip_html}}{% endif %}</p>
         </div>
         <div class="fr-col-4">
           <p class="fr-card__detail" style="text-align: right;">le <time datetime="{{ job.date | date:'%Y-%m-%d' }}">{{ job.date | date: "%d/%m/%Y" }}</time></p></div>


### PR DESCRIPTION
from the liquid doc : 
> You cannot change the order of operations using parentheses — parentheses are invalid characters in Liquid and will prevent your tags from working.
and 
> Strings, even when empty, are truthy.

also, I don't think `||` is a valid operator in Liquid.

I'm unsure why it never broke, I'm guessing this branch is unused.

I've reverted to the previous statement that was simpler from: 
https://github.com/betagouv/beta.gouv.fr/pull/6206/files#diff-3a3aa053b6b0e8c58c872c46f9104f381738114d24717957af9feb956b23e8c0L14