### PR TITLE
Fiche de poste API Entreprise

### DIFF
--- a/content/_authors/alexis.leclerc.md
+++ b/content/_authors/alexis.leclerc.md
@@ -1,6 +1,7 @@
 ---
 fullname: Alexis Leclerc
 role: Développeur
+github: haelle
 domaine: Développement
 missions:
   - start: 2017-03-01

--- a/content/_jobs/2021-09-20-developpeur_api_entreprise.md
+++ b/content/_jobs/2021-09-20-developpeur_api_entreprise.md
@@ -1,10 +1,9 @@
 ---
-roles: Développeur full-stack API Entreprise
+roles: Développeur - Développeuse full-stack API Entreprise
 startup: api-entreprise
 techno: Ruby on Rails, Ansible
 junior: true
 open: true
-title: Développeur full-stack API Entreprise
 ---
 
 ## API Entreprise

--- a/content/_jobs/2021-09-20-developpeur_api_entreprise.md
+++ b/content/_jobs/2021-09-20-developpeur_api_entreprise.md
@@ -1,0 +1,59 @@
+---
+roles: Développeur full-stack API Entreprise
+startup: api-entreprise
+techno: Ruby on Rails, Ansible
+junior: true
+open: true
+title: Développeur full-stack API Entreprise
+---
+
+## API Entreprise
+
+API Entreprise est une plateforme d'échanges de données entre administrations, cette plateforme s’adresse aux acteurs publics qui souhaitent opérer pour leur compte, ou faire opérer par un éditeur privé, un service de dématérialisation ou de simplification administrative nécessitant la mise en relation avec des fournisseurs d'informations publiques.
+
+## 🎯 Rôle et mission
+
+En lien avec les équipes de la DINUM chargées de la mise en œuvre de la politique d’ouverture et de circulation de la donnée, de l’architecture, de la SSI, des affaires juridiques, du déploiement des produits numériques de la DINUM et de France Connect :
+
+- Concevoir, réaliser, assurer l’hébergement, le suivi, la maintenance et l’évolution du produit entreprise.api.gouv.fr ;
+- Assurer l’intégration de logiciels et des développements dans une architecture principalement basée sur Ruby / Ruby on Rails, PostgreSQL, Redis, ElasticSearch et Javascript (VueJS, ES6) et sous système d’exploitation Debian GNU/Linux avec outil de déploiement Ansible ;
+- Réaliser le moissonnage, la normalisation, l’enrichissement et la fusion des jeux de données et de la surveillance au quotidien de leur qualité ;
+- Assurer la rédaction et le développement des tests automatisés sur les logiciels comme sur les données ;
+- Assurer l’administration applicative, système et réseau sur les serveurs dédiés, dans une infrastructure du commerce, standard et à faible coût ;
+- Mettre à disposition sous licence libre de l’ensemble des logiciels et de leur documentation (GitHub, Wiki, etc.)
+
+## 🔎 Profil recherché
+
+Savoirs :
+
+- Excellentes connaissances en développement logiciel (algorithmique, structuration de données, architecture logicielle, etc.) ;
+- Une expérience de3 ans minimum en langage de programmation Ruby et JavaScript est requise ;
+- Très bonne connaissance des données de référence sur les entreprises (SIRENE, RNCS, etc.) et les particuliers (quotient familial, revenu fiscal de référence, etc.) ;
+- Maîtrise des bonnes pratiques des outils de gestion de versions (Git) ;
+- Maitrise de l’anglais (écrit et oral).
+ 
+Savoir-faire :
+
+- Intégration et déploiement continu ;
+- Travailler en mode agile dans un environnement devops et lean ;
+- Maitriser Ansible.
+
+Savoir-être :
+
+- Fiabilité et rigueur dans l’exécution ;
+- Sens de l’organisation, de la priorisation et respect des délais de livraison d’un produit ;
+- Sens de l’écoute et du travail en équipe ;
+- Faire preuve d’empathie et de compréhension ;
+- Capacité à interagir avec une grande variété d’interlocuteurs ;
+
+Intérêt pour les produits développés par la DINUM contribuant à faciliter la circulation des données (API Entreprise, API Particulier, API.gouv.fr, Signup, France Connect, etc.).
+
+## 📝 Modalités
+
+Poste ouvret en CDD. Le télétravail est possible. Démarrage octobre/novembre 2021.
+
+## 🚀 Candidater
+
+Envoyer votre candidature à cette adresse : candidatures-DINUM@pm.gouv.fr et en copie romain.tales@modernisation.gouv.fr
+
+Offre référencée sur la [place de l'emploi public](https://place-emploi-public.gouv.fr/offre-emploi/developpeur-full-stack-api-entreprise-hf-reference-2021-700472/). 

--- a/content/_jobs/2021-09-20-developpeur_api_entreprise.md
+++ b/content/_jobs/2021-09-20-developpeur_api_entreprise.md
@@ -49,7 +49,7 @@ Intérêt pour les produits développés par la DINUM contribuant à faciliter l
 
 ## 📝 Modalités
 
-Poste ouvret en CDD. Le télétravail est possible. Démarrage octobre/novembre 2021.
+Poste ouvert en CDD. Le télétravail est possible. Démarrage octobre/novembre 2021.
 
 ## 🚀 Candidater
 


### PR DESCRIPTION
Ajout de la fiche de poste de développeur pour API Entreprise sur beta.gouv.fr.

Fiche d'origine [ici](https://place-emploi-public.gouv.fr/offre-emploi/developpeur-full-stack-api-entreprise-hf-reference-2021-700472/)