### PR TITLE
Mise à jour de date de fin mission

### DIFF
--- a/content/_authors/jerome.desboeufs.md
+++ b/content/_authors/jerome.desboeufs.md
@@ -13,7 +13,7 @@ missions:
     start: 2015-03-10
     status: service
   - employer: Living Data
-    end: 2021-11-07
+    end: 2022-01-15
     start: 2015-09-18
     status: independent
 startups:


### PR DESCRIPTION
Financement de la Base Adresse Nationale assuré par la DINUM jusqu’au 15 janvier 2022.