### PR TITLE
Prolongation Agnès Haasser

### DIFF
--- a/content/_authors/agnes.haasser.md
+++ b/content/_authors/agnes.haasser.md
@@ -6,9 +6,9 @@ github: tut-tuuut
 link: https://www.corelka.fr/
 missions:
   - start: 2021-01-05
-    end: 2021-11-06
+    end: 2022-05-30
     status: independent
-    employer: Octo
+    employer: Malt
 startups:
   - aidantsconnect
 ---


### PR DESCRIPTION
Prolongation de ma mission suite au renouvellement de marché.

Est-ce que je devais laisser `Octo` ou bien passer sur `Malt` pour le champ `employer` ?

## Review
Si c'est une fiche de membre : 
- [x] Les dates de fin correspondent à un contrat, convention ou budget validé
- [x] Les dates de fin sont après les dates de début
- [x] Les fiches auteurs sont dans content/_authors/

## Mise à jour de date de mission

:warning: Pour une simple mise à jour de dates de mission, tu peux merger toi-même sans relecture (tu auras juste à attendre 1-2 mins pour les tests passent)  
PS : Ne t'attends pas à ce qu'on le fasse pour toi !
