### PR TITLE
Ajout de la version 2.3 de l'API authors et startups

### DIFF
--- a/api/v2.3/authors.json
+++ b/api/v2.3/authors.json
@@ -1,0 +1,27 @@
+---
+layout: null
+---
+[
+    {% for author in site.authors %}
+        {
+            "id": "{{ author.id | remove:'/authors/' }}"
+            ,"fullname": "{{ author.fullname }}"
+            ,"role": "{{ author.role | escape }}"
+            ,"domaine": "{{ author.domaine | escape }}"
+            {% if author.github %},"github": "{{ author.github }}"{% endif %}
+            , "missions": [
+                {% for mission in author.missions %}
+                    { "start": "{{mission.start}}", "end": "{{mission.end}}", "status": "{{mission.status}}", "employer": "{{mission.employer}}" }{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% if author.startups %}
+            , "startups": [
+                {% for startup in author.startups %}
+                    "{{startup}}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% endif %}
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+]

--- a/api/v2.3/authors.json
+++ b/api/v2.3/authors.json
@@ -21,6 +21,13 @@ layout: null
                 {% endfor %}
             ]
             {% endif %}
+            {% if author.previously %}
+            , "previously": [
+                {% for previous in author.previously %}
+                    "{{previous}}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% endif %}
         }
         {% unless forloop.last %},{% endunless %}
     {% endfor %}

--- a/api/v2.3/startups.json
+++ b/api/v2.3/startups.json
@@ -1,0 +1,57 @@
+---
+layout: null
+---
+
+{ "links":
+    { "self": "{{ site.url }}/startups" }
+, "data":
+    [
+    {% for startup in site.startups %}
+        { "id"        : "{{ startup.id | remove: '/startups/' }}"
+        , "type"      : "startup"
+        , "attributes":
+            { "name"  : "{{ startup.title }}"
+            , "pitch" : "{{ startup.mission }}"{% if startup.stats %}
+            , "stats_url": "{% if startup.stats_url %}{{ startup.stats_url }}{% else %}{{ startup.link | strip }}/stats{% endif %}"{% endif %}{% if startup.link %}
+            , "link": "{{ startup.link}}"{% endif %}{% if startup.repository %}
+            , "repository": "{{ startup.repository}}"{% endif %}
+            , "contact": "{{startup.contact}}"
+            , "content_url_encoded_markdown": "{{startup.content_url_encoded_markdown}}"
+            , "events": [
+                {% for event in startup.events %}
+                    { "name": "{{event.name}}", "date": "{{event.date}}", "comment": "{{event.comment}}"}{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+                ]
+            , "phases": [
+                {% for phase in startup.phases %}
+                    { "name": "{{phase.name}}", "start": "{{phase.start}}", "end": "{{phase.end}}"}{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+                ]
+            }
+        , "relationships":
+            { "incubator":
+                { "data": { "type": "incubator", "id": "{{ startup.incubator}}" }
+                }
+            }
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    ]
+, "included":
+    [
+    {% for incubator in site.incubators %}
+        { "id"        : "{{ incubator.id | remove:'/incubateurs/approche' }}"
+        , "type"      : "incubator"
+        , "attributes":
+            { "title"  : "{{ incubator.title }}"
+            , "owner"  : "{{ incubator.owner }}"
+            , "website": "{{ incubator.website }}"
+            , "github" : "{{ incubator.github }}"
+            , "contact": "{{ incubator.contact }}"
+            }
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    ]
+
+}


### PR DESCRIPTION
Cette PR permet d'obtenir les informations sur les startups (actuelles et précédentes) d'un utilisateur via l'API (en ajoutant une nouvelle version : 2.3)

Par exemple, [pour ma fiche](https://raw.githubusercontent.com/betagouv/beta.gouv.fr/master/content/_authors/alejandro.mantecon-guillen.md), la version actuelle de l'API (2.2) affiche :

https://deploy-preview-7508--beta-gouv-fr.netlify.app/api/v2.2/authors.json
```json
{
        "id": "alejandro.mantecon-guillen"
        ,"fullname": "Alejandro Mantecon Guillen"
        ,"role": "Développeur"
        ,"domaine": "Développement"
        ,"github": "alemangui"
        , "missions": [        
                    { "start": "2019-05-13", "end": "2021-12-31", "status": "independent", "employer": ""}
            ]
        }
```

Alors que la version 2.3 afficherait ;

https://deploy-preview-7508--beta-gouv-fr.netlify.app/api/v2.3/authors.json
```json
{
       "id": "alejandro.mantecon-guillen"
       ,"fullname": "Alejandro Mantecon Guillen"
       ,"role": "Développeur"
       ,"domaine": "Développement"
       ,"github": "alemangui"
       , "missions": [
               { "start": "2019-05-13", "end": "2021-12-31", "status": "independent", "employer": "" } 
       ]
       , "startups": [
               "ma-cantine-egalim"
       ]
       , "previously": [
               "peps",
               "e-inspé"   
       ]
   }
```