### PR TITLE
Corrige des coquilles sur les pages de la BIN

### DIFF
--- a/_layouts/lpbin.html
+++ b/_layouts/lpbin.html
@@ -59,7 +59,7 @@ layout: default
                 <div class="fr-col-md-10 fr-col-xs-10">
                     <p>
                         <b>En quoi ces produits sont-ils différents ?</b><br />
-                        Les demandes du gouvernement diffèrent des services créés dans le cadre des programmes d'intrapreneuriat animés par beta.gouv : forte dimension politique, sentiment d'urgence, exposition médiatique importante. Plusieurs produits à fort impact sont nés de ce types de demandes comme : [Santé Psy Etudiant](https://www.santepsyetudiants.beta.gouv.fr/), [Aides-Jeunes](https://mes-aides.1jeune1solution.beta.gouv.fr/simulation), [JeVeuxAider](http://jeveuxaider.gouv.fr/), etc. 
+                        Les demandes du gouvernement diffèrent des services créés dans le cadre des programmes d'intrapreneuriat animés par beta.gouv : forte dimension politique, sentiment d'urgence, exposition médiatique importante. Plusieurs produits à fort impact sont nés de ce types de demandes comme : <a href='https://www.santepsyetudiants.beta.gouv.fr/'> Santé Psy Etudiant</a>, <a href="https://mes-aides.1jeune1solution.beta.gouv.fr/simulation">Aides-Jeunes</a>(), <a href="http://jeveuxaider.gouv.fr/">JeVeuxAider</a>, etc. 
                     </p>
                 </div>
             </div>

--- a/_layouts/lpbin.html
+++ b/_layouts/lpbin.html
@@ -49,7 +49,7 @@ layout: default
                     <b>Les demandes du Gouvernement, c'est-à-dire ?</b><br />
                     La majorité des services publics numériques construits dans le réseau beta.gouv naissent de problèmes soulevés par des agents publics devenus intrapreneur ou intrapreneuse afin de se dédier à la résolution des problèmes rencontrés sur le terrain par les citoyens ou les agents.
                     <br />
-                    En parallèle, beta.gouv répond également à des sollicitations parfois urgentes du gouvernement, directement portées par les ministères. Ces sollicitations relèvent de politiques publiques diverses (éducation, santé, transport, insertion, environnement), et donnent généralement lieu à la construction de services publics numériques ambitieux, qui ont généralement haut potentiel d'impact.  
+                    En parallèle, beta.gouv répond également à des sollicitations parfois urgentes du gouvernement, directement portées par les ministères. Ces sollicitations relèvent de politiques publiques diverses (éducation, santé, transport, insertion, environnement), et donnent généralement lieu à la construction de services publics numériques ambitieux, qui ont généralement un haut potentiel d'impact.  
                 </p>
             </div>
             <div class="fr-grid-row fr-grid-row--gutters">

--- a/_layouts/tmp_fiches_bin.html
+++ b/_layouts/tmp_fiches_bin.html
@@ -31,7 +31,7 @@ layout: default
 <div class="fr-py-6w fr-container">
     <section class="fr-accordion">
         <h2 class="fr-accordion__title">
-            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-81">2 coachs agiles et polyvalents</button>
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-81">3 coachs agiles et polyvalents</button>
         </h2>
         <div class="fr-collapse" id="accordion-81">
             <h3>Missions</h3>


### PR DESCRIPTION
Corrige les problèmes suivants : 
- les markdown sur la landing
- paragraphe les demandes du gouvernement c'est à dire ? dernière phrase il manque "qui ont généralement un haut potentiel"
- il y a écrit 2 au lieu de 3 coach sur les offres