### PR TITLE
Mise à jour équipe covoiturage

### DIFF
--- a/content/_authors/jonathan.fallon.md
+++ b/content/_authors/jonathan.fallon.md
@@ -5,9 +5,9 @@ domaine: Développement
 github: jonathanfallon
 missions:
     - start: 2018-11-05
-      end: 2021-12-31
+      end: 2022-12-31
       status: independent
-      employer: Codeurs en Liberté
+      employer: Scopopop
 startups:
     - preuve-de-covoiturage
 badges:

--- a/content/_authors/jonathan.kurtz.md
+++ b/content/_authors/jonathan.kurtz.md
@@ -5,9 +5,9 @@ domaine: Déploiement
 github: Jonathankurtz131
 missions:
     - start: 2019-08-28
-      end: 2021-12-31
+      end: 2022-12-31
       status: independent
-      employer: Codeurs en Liberté
+      employer: Scopopop
 startups:
     - preuve-de-covoiturage
     - aides-territoires

--- a/content/_authors/julien.parmentier.md
+++ b/content/_authors/julien.parmentier.md
@@ -4,9 +4,9 @@ role: Développeur
 github: P3rceval
 missions:
   - start: 2021-05-10
-    end: 2021-12-31
+    end: 2022-12-31
     status: independent
-    employer: Codeurs en Liberté
+    employer: Scopopop
 startups:
   - preuve-de-covoiturage
 domaine: Développement

--- a/content/_authors/ludovic.delhomme.md
+++ b/content/_authors/ludovic.delhomme.md
@@ -6,8 +6,9 @@ link: https://datayama.fr
 github: datayama38
 missions:
   - start: 2021-03-03
-    end: 2021-12-31
+    end: 2022-12-31
     status: independent
+    employer: Scopopop
 startups:
   - preuve-de-covoiturage
 ---

--- a/content/_authors/nicolas.merigot.md
+++ b/content/_authors/nicolas.merigot.md
@@ -5,9 +5,11 @@ domaine: Développement
 github: nmrgt
 missions:
     - start: 2019-01-28
-      end: 2021-12-31
+      end: 2022-12-31
       status: independent
-      employer: Codeurs en Liberté
+      employer: Scopopop
 startups:
     - preuve-de-covoiturage
+badge:
+    - segur
 ---

--- a/content/_authors/nicolas.merigot.md
+++ b/content/_authors/nicolas.merigot.md
@@ -10,6 +10,4 @@ missions:
       employer: Scopopop
 startups:
     - preuve-de-covoiturage
-badge:
-    - segur
 ---

--- a/content/_authors/nicolas.viennot.md
+++ b/content/_authors/nicolas.viennot.md
@@ -8,7 +8,7 @@ missions:
   - start: 2021-08-30
     end: 2022-03-30
     status: independent
-    employer: DINUM
+    employer: Scopopop
 startups:
   - preuve-de-covoiturage
 ---

--- a/content/_authors/victor.stefanini.md
+++ b/content/_authors/victor.stefanini.md
@@ -5,8 +5,9 @@ domaine: Déploiement
 github: victorstefanini
 missions:
   - start: 2021-09-02
-    end: 2021-12-31
+    end: 2022-12-31
     status: independent
+    employer: Scopopop
 startups:
   - preuve-de-covoiturage
 badges:


### PR DESCRIPTION
Mise à jour des dates de fin et de l'employeur de l'équipe covoiturage. Prolongement d'un an suite au refinancement pour 2022.