### PR TITLE
Proposition de passer en partenariats passés

### DIFF
--- a/content/_startups/attractivite.des.territoires.md
+++ b/content/_startups/attractivite.des.territoires.md
@@ -15,6 +15,8 @@ events: []
 phases:
   - name: construction
     start: 2021-11-02
+    name : alumni
+    start : 2022-01-11
 ---
 ## Contexte
 


### PR DESCRIPTION
Au vu du changement du mode de développement de l'outil (repris par les équipes SSI de la DTNum) et de l'abandon de coaching beta, je propose de passer ce produit en "partenariats passés". Cela signifie que les équipes beta.gouv.fr n'accompagnent plus activement le projet, qui continue à être développé par la DTNum. 