### PR TITLE
Suppression des \ superflus dans l’offre designer junior itou

### DIFF
--- a/content/_jobs/2022-01-10-ui.designer.junior.1.md
+++ b/content/_jobs/2022-01-10-ui.designer.junior.1.md
@@ -4,7 +4,7 @@ open: true
 junior: true
 date: 2022-01-10T13:33:21.604Z
 ---
-# UI Designer Junior\
+# UI Designer Junior
 La plateforme de l'inclusion
 
 ## 👋 Contexte
@@ -15,7 +15,7 @@ La plateforme de l'inclusion
 
 [La plateforme de l’inclusion](https://inclusion.beta.gouv.fr/) est un ensemble de **4 services** dont l’objectif est d’augmenter le nombre de personnes entrant en dans un parcours d’Insertion par l’Activité Économique.
 
-[\*\*Les emplois de l’inclusion](https://emplois.inclusion.beta.gouv.fr/) : Faciliter l’orientation et l’embauche\*\* de candidats à un emploi accompagné vers des [employeurs solidaires](https://doc.inclusion.beta.gouv.fr/presentation/employeurs-solidaires) (SIAE, GEIQ, EA) en centralisant un registre de l’offre et en refondant l’agrément IAE.(faciliter les recrutements des personnes en difficultés).
+[**Les emplois de l’inclusion](https://emplois.inclusion.beta.gouv.fr/) : Faciliter l’orientation et l’embauche** de candidats à un emploi accompagné vers des [employeurs solidaires](https://doc.inclusion.beta.gouv.fr/presentation/employeurs-solidaires) (SIAE, GEIQ, EA) en centralisant un registre de l’offre et en refondant l’agrément IAE.(faciliter les recrutements des personnes en difficultés).
 
 **[La communauté de l’inclusion](https://communaute.inclusion.beta.gouv.fr/)** : **Faciliter les échanges entre acteurs de l’inclusion** pour améliorer l’accompagnement des personnes et alimenter les politiques publiques.
 
@@ -27,39 +27,39 @@ La plateforme de l'inclusion
 
 **La mission portera principalement sur *Les emplois de l’inclusion* et *Le marché de l’inclusion***
 
-**Participation à la conception du design System :** \
-- Maitrise de Figma : composants, styles, auto-layout...\
-- Création de composants à intégrer dans notre UI kit. \
-- Sensibilité en accessibilité web. \
+**Participation à la conception du design System :**
+- Maitrise de Figma : composants, styles, auto-layout...
+- Création de composants à intégrer dans notre UI kit.
+- Sensibilité en accessibilité web.
 - Être attentif à la cohérence du design system.
 
-**Conception d’interface :**\
-- Être à l’aise avec la transformation de maquette wireframe vers une UI à livrer à notre intégrateur ou développeur(s). \
-- Compétences en design graphique (hiérarchie de l’information etc.) \
-- Capacité à faire des prototypes interactifs. \
-- Capacité à proposer des visuels en lien avec le sujet traité. \
-- Bonne connaissance/ fonctionnement des composants présent sur le web.\
- \
-**Travail avec les développeurs :** \
-- Produire et livrer des maquettes facilitant le travail des développeurs. \
-- Travail avec les développeurs pour la livraison des maquettes. \
-- Notions techniques (responsive, HTML/CSS/JS, animations). \
+**Conception d’interface :**
+- Être à l’aise avec la transformation de maquette wireframe vers une UI à livrer à notre intégrateur ou développeur(s).
+- Compétences en design graphique (hiérarchie de l’information etc.)
+- Capacité à faire des prototypes interactifs.
+- Capacité à proposer des visuels en lien avec le sujet traité.
+- Bonne connaissance/ fonctionnement des composants présent sur le web.
+
+**Travail avec les développeurs :**
+- Produire et livrer des maquettes facilitant le travail des développeurs.
+- Travail avec les développeurs pour la livraison des maquettes.
+- Notions techniques (responsive, HTML/CSS/JS, animations).
 - Connaissance d’un framework web type Bootstrap ou équivalent.
 
-**Travail avec les UX :**\
-- Participation aux tests utilisateurs ou interviews. \
-- Compréhension des problématiques à traiter. \
-- Participation aux rituels hebdomadaires et au travail en binôme.\
+**Travail avec les UX :**
+- Participation aux tests utilisateurs ou interviews.
+- Compréhension des problématiques à traiter.
+- Participation aux rituels hebdomadaires et au travail en binôme.
 - Envie de travailler à plusieurs.
 
-**Conditions :**\
-- Poste ouvert pour un indépendant ou une indépendante. \
-- Mission 3 jours par semaine.\
-- Travail à distance.\
-- TJM à définir selon profil.\
+**Conditions :**
+- Poste ouvert pour un indépendant ou une indépendante.
+- Mission 3 jours par semaine.
+- Travail à distance.
+- TJM à définir selon profil.
 - 2 entretiens sont prévus à distance Book UI.
 
-**Case Study :**\
+**Case Study :**
 Un petit test sera à présenter lors de l’entretien, il n’est pas nécessaire d’y passer plus de 2 heures, nous souhaitons surtout connaitre votre démarche, votre compréhension.
 
 Pour postuler à cette offre, envoyez votre CV + book à **[anne.pichon@beta.gouv.fr](mailto:anne.pichon@beta.gouv.fr)**


### PR DESCRIPTION
Un copier/collier (depuis notion?) a introduit des \ qui n’ont rien à faire dans l’offre pour un designer junior chez itou, cette PR corrige cela.

![Sélection_186](https://user-images.githubusercontent.com/1223316/149296572-9928f325-8ae9-4836-9a67-1c5670af4606.png)
