### PR TITLE
Correction du lien "guide candidats" (#8757)

### DIFF
--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -39,7 +39,7 @@ layout: default
             <h3 class="fr-card__title">
               Vous souhaitez candidater à une offre&nbsp;? 
             </h3>
-              <a class="fr-btn fr-btn--sm fr-enlarge-link fr-btn--secondary button-white-border" href="https://doc.incubateur.net/communaute/travailler-a-beta-gouv/recrutement/guide-pour-les-candidat-e-s">Découvrez notre guide pour les candidat(e)s</a>
+              <a class="fr-btn fr-btn--sm fr-enlarge-link fr-btn--secondary button-white-border" href="https://doc.incubateur.net/communaute/travailler-a-beta-gouv/actions-transverses/guide-pour-les-candidat-e-s">Découvrez notre guide pour les candidat(e)s</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Je ne suis pas sûr à 200% du lien, mais je crois que c'est probablement bon.

Voir #8757 pour le contexte.