### PR TITLE
ajout pages de confirmation inscription newsletter

### DIFF
--- a/_pages/confirmation-newsletter.md
+++ b/_pages/confirmation-newsletter.md
@@ -1,0 +1,8 @@
+---
+layout: page
+permalink: /confirmez-votre-email/
+title: Merci de valider  votre email
+---
+## Vous y êtes presque!
+Un email vous a été envoyé. Merci de cliquer dans le lien présent dans ce message. 
+

--- a/_pages/newsletter-merci.md
+++ b/_pages/newsletter-merci.md
@@ -1,0 +1,7 @@
+---
+layout: page
+permalink: /newsletter-merci/
+title: Votre inscription est validée
+---
+## Merci 
+


### PR DESCRIPTION
Hello, 

Nous avons mis en ligne le nouveau formulaire d'inscription Sendinblue.

Suite à cela, j'ai rajouté 2 pages (cachés) qui vont nous servir à calculer des taux de conversions mais aussi prévenir les inscrits a la Newsletter qu'ils doivent valider un email  pour s'inscrire. 

![Capture d’écran 2022-01-31 à 12 28 20](https://user-images.githubusercontent.com/3593868/151786100-5452cdbe-3d9f-4b27-be7d-a3d121b13ab5.png)


![Capture d’écran 2022-01-31 à 12 27 32](https://user-images.githubusercontent.com/3593868/151785990-54576e8a-bf8c-44d4-b92f-c8e325a131da.png)

