### PR TITLE
Offre pourvue data analyst pour le pilotage de l'inclusion 

### DIFF
--- a/content/_jobs/2022-01-10-itou-data-analyst.md
+++ b/content/_jobs/2022-01-10-itou-data-analyst.md
@@ -4,7 +4,7 @@ title: La plateforme de l'inclusion recrute un ou une data analyst
 contrat: indépendant
 startup: pilotage.de.linclusion
 contact: recrutement@inclusion.beta.gouv.fr
-open: true
+open: false
 ---
 
 # La plateforme de l'inclusion recrute un ou une data analyst


### PR DESCRIPTION
Retirer l'offre d'emploi pour le poste de data analyst pour le pilotage de l'inclusion