### PR TITLE
Corrige nom de "startup" openfisca sur fiche de membre

### DIFF
--- a/content/_authors/sandra.chakroun.md
+++ b/content/_authors/sandra.chakroun.md
@@ -10,8 +10,9 @@ missions:
     start: 2017-05-10
     status: independent
 startups:
-  - _openfisca_
+  - openfisca
   - leximpact
   - camino
   - aides.jeunes
+  - dotations-locales
 ---


### PR DESCRIPTION
Corrige me fiche de membre maintenant que le commun contributif OpenFisca a de nouveau une fiche de startup.
Et ajoute un rattachement à la nouvelle startup dotations locales.

---

## Publication

`beta.gouv.fr` est un site qui ne ressemble pas aux sites administratifs classiques, tout comme les produits qu'il porte.

Cependant, en tant que domaine en `.gouv`, les communications qui y sont faites engagent la responsabilité de l'administration qui héberge l'Incubateur. Toute personne proposant du contenu à publier sur `beta.gouv.fr` doit donc être pleinement consciente que les élasticités règlementaires qui nous permettent de fonctionner ne peuvent exister qu'avec une forme d'auto-régulation. **Demandez l'avis de membres plus anciens que vous avant de publier du contenu.**

## Review
Si c'est une fiche de membre : 
- [ ] Les dates de fin correspondent à un contrat, convention ou budget validé
- [ ] Les dates de fin sont après les dates de début
- [ ] Les fiches auteurs sont dans content/_authors/


