### PR TITLE
Maj abandons 2021

### DIFF
--- a/content/_startups/auto-partage.md
+++ b/content/_startups/auto-partage.md
@@ -9,9 +9,6 @@ phases:
     end: 2020-11-30
   - name: alumni
     start: 2020-12-01
-events:
-  - name: end
-    date: 2021-12-31
 link: 
 repository: 
 stats: false

--- a/content/_startups/candela.md
+++ b/content/_startups/candela.md
@@ -15,9 +15,6 @@ phases:
   - name: alumni
     start: 2021-07-09
     end: 2021-10-15
-events:
-  - name: end
-    date: 2021-12-31
 ---
 ## Contexte
 

--- a/content/_startups/culture_amateurs.md
+++ b/content/_startups/culture_amateurs.md
@@ -9,6 +9,9 @@ phases:
     end: 2021-02-01
   - name: alumni
     start: 2021-02-01
+events:
+  - name: end
+    date: 2021-12-31
 link:
 repository:
 stats: false

--- a/content/_startups/e-inspé.md
+++ b/content/_startups/e-inspé.md
@@ -8,9 +8,6 @@ phases:
   - name: construction
     start: 2020-06-10
   - name: alumni
-events:
-  - name: end
-    date: 2021-02-01
 ---
 La phase d’investigation menée par Réseau Canopé et Beta.gouv a montré que les enseignants suivaient toutes sortes de formations de leur initiative personnelle ou par obligation, venues de l'Education nationale ou d'ailleurs, mais sans parvenir à leur donner une cohérence globale et un suivi dans le temps.
 

--- a/content/_startups/efti.md
+++ b/content/_startups/efti.md
@@ -15,9 +15,6 @@ phases:
     end: 2021-10-02
   - name: alumni
     start: 2021-10-02
-events:
-  - name: end
-    date: 2021-12-31
 ---
 ## Contexte
 

--- a/content/_startups/rdv.consulat.md
+++ b/content/_startups/rdv.consulat.md
@@ -16,6 +16,9 @@ phases:
   - name: alumni
     comment: Choix d'une solution en interne plutôt qu'un lancement de Startup d'Etat
     start: 2021-03-05
+events:
+  - name: end
+    date: 2021-12-31
 ---
 # Contexte
 


### PR DESCRIPTION
11 abandons en 2021 : 

Liste des produits abandonnés en 2021 :
Certaines commandes ministérielles ont été abandonnées après la phase d’investigation. En effet, la phase d’investigation a démontré que le développement d’une nouvelle solution numérique n’était pas nécessaire, soit parce qu’elle ne résoudrait pas le problème visé, soit parce qu’un service numérique qui répond au problème existe déjà : 
Atlas des Paysages (ministère de la Transition écologique) : systématiser la prise en compte des paysages dans les projets d'aménagement du territoire
RDVConsulat (ministère de l’Europe et des Affaires étrangères) : réduire les difficultés liées aux prises de rendez-vous dans les consulats
Rail’Up (ministère chargé des Transports) : simplifier les demandes de licences d'entreprise ferroviaire
Dumas (ministère de l’Europe et des Affaires étrangères) : résoudre les problèmes rencontrés par le réseau culturel français à l'étranger
Culture Amateur (ministère de la Culture) : développer les pratiques culturelles des amateurs
Non recours au service public de l’emploi et de l’insertion (ministère du Travail) : faciliter l'accès des personnes dites 'invisibles' aux dispositifs d'accompagnement vers l'emploi
La bonne place (Pôle emploi) : mettre en relation demandeurs d'emploi et entreprise de façon à ce que cela dure
Plateforme d’innovation urbaine (ministère de la Transition écologique) : favoriser la mise en place de solutions d'innovation urbaine
Hydrogène (ministère de la Transition écologique) : accélérer la création de la filière française de production d'hydrogène décarboné
Certains produits déjà lancés ont été arrêtés suite à un comité d’investissement où les résultats des expérimentations n’étaient pas assez concluants pour justifier une poursuite du service (manque d’impact, pas d’utilisateurs, etc) :
La plateforme Talents numériques (DINUM) qui avait pour objectif de ​​créer une communauté de partage, valoriser les expertises des agents du numérique et faciliter leur mise en relation, a été arrêtée en 2021
La plateforme Peps (ministère de l’Agriculture et de l’alimentation) : la plateforme de partage d'expérience entre agriculteurs lancée en 2019 avec le ministère de l'agriculture a été transférée à une association partant du constat que les mesures d'impact de la plateforme ne justifiaient pas la poursuite d’un portage État.