### PR TITLE
remove extraneous quotes on startup layout

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -35,7 +35,7 @@ L'équipe est portée par <a href="/startups/?incubateur={{ incubator_id | remov
 L'équipe est sponsorisée par
 {% for sponsorId in page.sponsors %}
   {% assign sponsor = site.organisations | where: 'id', sponsorId | first %}
-  {% if forloop.index > 1 %}, {% endif %}{{sponsor.name}}"
+  {% if forloop.index > 1 %}, {% endif %}{{sponsor.name}}
 {% endfor %}
 {% endcapture %}
 


### PR DESCRIPTION
<img width="786" alt="Screenshot 2022-03-22 at 18 40 06" src="https://user-images.githubusercontent.com/883348/159542772-14732748-3535-4e74-838d-462836a05e5f.png">

introduced in https://github.com/betagouv/beta.gouv.fr/commit/1ccb1dc0fbbf86216dc105db850579224ce246c9#diff-bf4324e8d4abe5960707b2d1a45c9436380160562e60fed5d60068e2f36a44f9R38

cf fix in https://betagouv-site-pr9400.osc-fr1.scalingo.io/startups/api-entreprise.html
