### PR TITLE
Mise à jour fiche Loïc Delmaire

### DIFF
--- a/content/_authors/loic.delmaire.md
+++ b/content/_authors/loic.delmaire.md
@@ -4,18 +4,18 @@ role: Développeur
 domaine: Développement
 github: skelz0r
 missions:
-  - start: 2013-12-01
-    end: 2014-05-31
-    status: admin
-    employer: dinum
-  - start: 2020-09-01
-    end: 2022-03-31
-    status: independent
-    employer: octo
+    - start: 2013-12-01
+      end: 2014-05-31
+      status: admin
+      employer: dinum
+    - start: 2020-09-01
+      end: 2022-06-30
+      status: independent
+      employer: octo, malt
 startups:
-  - api-entreprise
+    - api-entreprise
 previously:
-  - mps
+    - mps
 ---
 
 Je parle à des canards.


### PR DESCRIPTION
- Extension de la mission jusqu'à fin juin
- Mission en 2022 est portée par Malt (et non Octo)