### PR TITLE
Nouveau nom pour la DGITM

### DIFF
--- a/content/_organisations/dgitm.md
+++ b/content/_organisations/dgitm.md
@@ -1,5 +1,5 @@
 ---
-name: Direction générale des infrastructures, des transports et de la mer
+name: Direction générale des infrastructures, des transports et des mobilités
 acronym: DGITM
 domaine_ministeriel: environnement
 type: administration-centrale


### PR DESCRIPTION
La DGITM a récemment changé de nom !

https://www.ecologie.gouv.fr/direction-generale-des-infrastructures-des-transports-et-des-mobilites-dgitm
https://lannuaire.service-public.fr/gouvernement/administration-centrale-ou-ministere_172170