### PR TITLE
🗒️ 🖊️ Rajout de nouveaux champs dans les fiches startup

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -106,6 +106,15 @@ L'équipe
 {% endif %}
 {% endcapture %}
 
+{% capture accessibilite %}
+Le statut d'accessibilité du produit est :
+{% if page.accessibility_status %}
+  <em>{{ page.investigation_outputs_url }}</em>
+{% else %}
+  <em>non-conforme</em>
+{% endif %}
+{% endcapture %}
+
 <div class="notification full-width section-grey">
   <div class="fr-container">
     <ul>
@@ -116,6 +125,7 @@ L'équipe
       <li>{{ statistiques_info }}</li>
       <li>{{ source_info }}</li>
       <li>{{ budget_info }}</li>
+      <li>{{ accessibilite }}</li>
       <li>{{ analyse_risques }}</li>
       <li>{{ dashlord }}</li>
       <li>{{ investigation_docs }}</li>

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -88,6 +88,15 @@ L'équipe
 {% endif %}
 {% endcapture %}
 
+{% capture dashlord %}
+Le suivi des bonnes pratiques de ce produit
+{% if page.dashlord_url %}
+  est disponible sur <a href="{{ page.dashlord_url }}" title="Dashlord de {{ page.title }}"> Dashlord</a>.
+{% else %}
+  <em>n'est pas encore disponible sur <a href="https://dashlord.incubateur.net" title="Dashlord">Dashlord</a>.</em>
+{% endif %}
+{% endcapture %}
+
 <div class="notification full-width section-grey">
   <div class="fr-container">
     <ul>
@@ -99,6 +108,7 @@ L'équipe
       <li>{{ source_info }}</li>
       <li>{{ budget_info }}</li>
       <li>{{ analyse_risques }}</li>
+      <li>{{ dashlord }}</li>
       {% if page.techno %}
       <li>{{ techno_info }}</li>
       {% endif %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -97,6 +97,15 @@ Le suivi des bonnes pratiques de ce produit
 {% endif %}
 {% endcapture %}
 
+{% capture investigation_docs %}
+L'équipe 
+{% if page.investigation_outputs_url %}
+  a publié <a href="{{ page.investigation_outputs_url }}" title="Documents d'investigation de {{ page.title }}"> les rendus de sa phase d'investigation</a>.
+{% else %}
+  <em>n'a pas publié les rendus de sa phase d'investigation.</em>
+{% endif %}
+{% endcapture %}
+
 <div class="notification full-width section-grey">
   <div class="fr-container">
     <ul>
@@ -109,6 +118,7 @@ Le suivi des bonnes pratiques de ce produit
       <li>{{ budget_info }}</li>
       <li>{{ analyse_risques }}</li>
       <li>{{ dashlord }}</li>
+      <li>{{ investigation_docs }}</li>
       {% if page.techno %}
       <li>{{ techno_info }}</li>
       {% endif %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -77,6 +77,17 @@ L’équipe ne communique pas encore sur son budget.
 Technologies utilisées : {{ page.techno | join: ", " }}
 {% endcapture %}
 
+{% capture analyse_risques %}
+L'équipe
+{% if page.analyse_risques_url %}
+  a réalisé un atelier <a href="{{ page.analyse_risques_url }}" title="Analyse de risques de {{ page.title }}"> d'analyse de risques</a>.
+{% elif page.analyse_risques %}
+  a réalisé un atelier d'analyse de risques mais ne le rend pas encore public.
+{% else %}
+  <em>n'a pas encore réalisé son atelier d'analyse de risques.</em>
+{% endif %}
+{% endcapture %}
+
 <div class="notification full-width section-grey">
   <div class="fr-container">
     <ul>
@@ -87,6 +98,7 @@ Technologies utilisées : {{ page.techno | join: ", " }}
       <li>{{ statistiques_info }}</li>
       <li>{{ source_info }}</li>
       <li>{{ budget_info }}</li>
+      <li>{{ analyse_risques }}</li>
       {% if page.techno %}
       <li>{{ techno_info }}</li>
       {% endif %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -78,13 +78,12 @@ Technologies utilisées : {{ page.techno | join: ", " }}
 {% endcapture %}
 
 {% capture analyse_risques %}
-L'équipe
 {% if page.analyse_risques_url %}
-  a réalisé un atelier <a href="{{ page.analyse_risques_url }}" title="Analyse de risques de {{ page.title }}"> d'analyse de risques</a>.
+  L'équipe a réalisé un atelier <a href="{{ page.analyse_risques_url }}" title="Analyse de risques de {{ page.title }}"> d'analyse de risques</a>.
 {% elsif page.analyse_risques %}
-  a réalisé un atelier d'analyse de risques mais ne le rend pas encore public.
-{% else %}
-  <em>n'a pas encore réalisé son atelier d'analyse de risques.</em>
+  L'équipe a réalisé un atelier d'analyse de risques mais ne le rend pas encore public.
+{% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status='transfer' %}
+  <em>n'a pas encore réalisé ou publié son atelier d'analyse de risques.</em>
 {% endif %}
 {% endcapture %}
 
@@ -94,15 +93,6 @@ Le suivi des bonnes pratiques de ce produit
   est disponible sur <a href="{{ page.dashlord_url }}" title="Dashlord de {{ page.title }}"> Dashlord</a>.
 {% else %}
   <em>n'est pas encore disponible sur <a href="https://dashlord.incubateur.net" title="Dashlord">Dashlord</a>.</em>
-{% endif %}
-{% endcapture %}
-
-{% capture investigation_docs %}
-L'équipe 
-{% if page.investigation_outputs_url %}
-  a publié <a href="{{ page.investigation_outputs_url }}" title="Documents d'investigation de {{ page.title }}"> les rendus de sa phase d'investigation</a>.
-{% else %}
-  <em>n'a pas publié les rendus de sa phase d'investigation.</em>
 {% endif %}
 {% endcapture %}
 

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -82,7 +82,7 @@ Technologies utilisées : {{ page.techno | join: ", " }}
 <li>L'équipe a réalisé un atelier <a href="{{ page.analyse_risques_url }}" title="Analyse de risques de {{ page.title }}"> d'analyse de risques</a>.</li>
 {% elsif page.analyse_risques %}
   <li>L'équipe a réalisé un atelier d'analyse de risques mais ne le rend pas encore public.</li>
-{% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status='transfer' %}
+{% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status == 'transfer' %}
 <li>L'équipe <em>n'a pas encore réalisé ou publié son atelier d'analyse de risques.</em></li>
 {% endif %}
 {% endcapture %}
@@ -99,7 +99,7 @@ Le suivi des bonnes pratiques de ce produit
 {% capture accessibilite %}
 {% if page.accessibility_status %}
 <li>Le statut d'accessibilité du produit est : <em>{{ page.investigation_outputs_url }}</em></li>
-{% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status='transfer' %}
+{% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status == 'transfer' %}
 <li>Le statut d'accessibilité du produit est : <em>non-conforme</em></li>
 {% endif %}
 {% endcapture %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -81,7 +81,7 @@ Technologies utilisées : {{ page.techno | join: ", " }}
 L'équipe
 {% if page.analyse_risques_url %}
   a réalisé un atelier <a href="{{ page.analyse_risques_url }}" title="Analyse de risques de {{ page.title }}"> d'analyse de risques</a>.
-{% elif page.analyse_risques %}
+{% elsif page.analyse_risques %}
   a réalisé un atelier d'analyse de risques mais ne le rend pas encore public.
 {% else %}
   <em>n'a pas encore réalisé son atelier d'analyse de risques.</em>

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -107,11 +107,10 @@ L'équipe
 {% endcapture %}
 
 {% capture accessibilite %}
-Le statut d'accessibilité du produit est :
 {% if page.accessibility_status %}
-  <em>{{ page.investigation_outputs_url }}</em>
-{% else %}
-  <em>non-conforme</em>
+Le statut d'accessibilité du produit est : <em>{{ page.investigation_outputs_url }}</em>
+{% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status='transfer' %}
+Le statut d'accessibilité du produit est : <em>non-conforme</em>
 {% endif %}
 {% endcapture %}
 
@@ -125,17 +124,7 @@ Le statut d'accessibilité du produit est :
       <li>{{ statistiques_info }}</li>
       <li>{{ source_info }}</li>
       <li>{{ budget_info }}</li>
-      {% if page.accessibility_status %}
-        <li>
-         Le statut d'accessibilité du produit est :
-         <em>{{ page.investigation_outputs_url }}</em>
-        </li>
-       {% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status='transfert' %}
-       <li>
-        Le statut d'accessibilité du produit est :
-        <em>non-conforme</em>
-       </li>
-      {% endif %}
+      <li>{{ accessibilite }}</li>
       <li>{{ analyse_risques }}</li>
       <li>{{ dashlord }}</li>
       <li>{{ investigation_docs }}</li>

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -125,7 +125,17 @@ Le statut d'accessibilité du produit est :
       <li>{{ statistiques_info }}</li>
       <li>{{ source_info }}</li>
       <li>{{ budget_info }}</li>
-      <li>{{ accessibilite }}</li>
+      {% if page.accessibility_status %}
+        <li>
+         Le statut d'accessibilité du produit est :
+         <em>{{ page.investigation_outputs_url }}</em>
+        </li>
+       {% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status='transfert' %}
+       <li>
+        Le statut d'accessibilité du produit est :
+        <em>non-conforme</em>
+       </li>
+      {% endif %}
       <li>{{ analyse_risques }}</li>
       <li>{{ dashlord }}</li>
       <li>{{ investigation_docs }}</li>

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -79,11 +79,11 @@ Technologies utilisées : {{ page.techno | join: ", " }}
 
 {% capture analyse_risques %}
 {% if page.analyse_risques_url %}
-  L'équipe a réalisé un atelier <a href="{{ page.analyse_risques_url }}" title="Analyse de risques de {{ page.title }}"> d'analyse de risques</a>.
+<li>L'équipe a réalisé un atelier <a href="{{ page.analyse_risques_url }}" title="Analyse de risques de {{ page.title }}"> d'analyse de risques</a>.</li>
 {% elsif page.analyse_risques %}
-  L'équipe a réalisé un atelier d'analyse de risques mais ne le rend pas encore public.
+  <li>L'équipe a réalisé un atelier d'analyse de risques mais ne le rend pas encore public.</li>
 {% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status='transfer' %}
-  <em>n'a pas encore réalisé ou publié son atelier d'analyse de risques.</em>
+<li>L'équipe <em>n'a pas encore réalisé ou publié son atelier d'analyse de risques.</em></li>
 {% endif %}
 {% endcapture %}
 
@@ -98,9 +98,9 @@ Le suivi des bonnes pratiques de ce produit
 
 {% capture accessibilite %}
 {% if page.accessibility_status %}
-Le statut d'accessibilité du produit est : <em>{{ page.investigation_outputs_url }}</em>
+<li>Le statut d'accessibilité du produit est : <em>{{ page.investigation_outputs_url }}</em></li>
 {% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status='transfer' %}
-Le statut d'accessibilité du produit est : <em>non-conforme</em>
+<li>Le statut d'accessibilité du produit est : <em>non-conforme</em></li>
 {% endif %}
 {% endcapture %}
 
@@ -114,10 +114,9 @@ Le statut d'accessibilité du produit est : <em>non-conforme</em>
       <li>{{ statistiques_info }}</li>
       <li>{{ source_info }}</li>
       <li>{{ budget_info }}</li>
-      <li>{{ accessibilite }}</li>
-      <li>{{ analyse_risques }}</li>
+      {{ accessibilite }}
+      {{ analyse_risques }}
       <li>{{ dashlord }}</li>
-      <li>{{ investigation_docs }}</li>
       {% if page.techno %}
       <li>{{ techno_info }}</li>
       {% endif %}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -107,6 +107,43 @@ collections:
         name: budget_url
         widget: string
         required: false
+      - label: Lien vers la page Dashlord
+        hint : >
+          Pour inscrire ta startup sur dashlord.incubateur.net, visite https://github.com/betagouv/dashlord/blob/main/dashlord.yml
+        name: dashlord_url
+        widget: string
+        required: false
+      - label: Analyse de risque
+        hint : >
+          Indique si ta startup à déjà réalisé un atelier d'analyse de risque agile.
+        name: analyse_risques
+        widget: boolean
+        required: false
+      - label: Lien vers l'analyse de risques
+        hint : >
+          Si ta SE a rendu son analyse de risques publique, tu peux indiquer le lien vers ce document ici.
+        name: analyse_risques_url
+        widget: string
+        required: false
+      - label: Lien vers les rendus de la phase d'investigation
+        hint : >
+          Tu peux publier les documents écrits pendant la phase d'investigation de ta SE (synthèse, présentation de comité, etc.)
+        name: investigation_outputs_url
+        widget: string
+        required: false
+      - label: Statut d'accessibilité
+        hint : >
+          Le statut d'accessibilité de ton produit. Si tu ne sais pas remplir ce champs, indique "non conforme".
+        name: accessibility_status
+        widget: list
+        collapsed: false
+        fields:
+          - label: Sponsor
+            name: name
+            widget: select
+            default: "non conforme"
+            options: ["totalement conforme", "partiellement conforme", "non conforme"]
+        required: false
       - label: Évènements marquants
         name: events
         label_singular: évènement marquant

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -125,12 +125,6 @@ collections:
         name: analyse_risques_url
         widget: string
         required: false
-      - label: Lien vers les rendus de la phase d'investigation
-        hint : >
-          Tu peux publier les documents écrits pendant la phase d'investigation de ta SE (synthèse, présentation de comité, etc.)
-        name: investigation_outputs_url
-        widget: string
-        required: false
       - label: Statut d'accessibilité
         hint : >
           Le statut d'accessibilité de ton produit. Si tu ne sais pas remplir ce champs, indique "non conforme".

--- a/api/v2.5/authors.json
+++ b/api/v2.5/authors.json
@@ -1,0 +1,34 @@
+---
+layout: null
+---
+[
+    {% for author in site.authors %}
+        {
+            "id": "{{ author.id | remove:'/authors/' }}"
+            ,"fullname": "{{ author.fullname }}"
+            ,"role": "{{ author.role | escape }}"
+            ,"domaine": "{{ author.domaine | escape }}"
+            {% if author.github %},"github": "{{ author.github }}"{% endif %}
+            , "missions": [
+                {% for mission in author.missions %}
+                    { "start": "{{mission.start}}", "end": "{{mission.end}}", "status": "{{mission.status}}", "employer": "{{mission.employer}}" }{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% if author.startups %}
+            , "startups": [
+                {% for startup in author.startups %}
+                    "{{startup}}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% endif %}
+            {% if author.previously %}
+            , "previously": [
+                {% for previous in author.previously %}
+                    "{{previous}}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% endif %}
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+]

--- a/api/v2.5/incubators.json
+++ b/api/v2.5/incubators.json
@@ -1,0 +1,5 @@
+---
+layout: null
+---
+
+{% render_incubators_api %}

--- a/api/v2.5/startups.json
+++ b/api/v2.5/startups.json
@@ -12,9 +12,9 @@ layout: null
         , "attributes":
             { "name"  : "{{ startup.title }}"
             , "pitch" : "{{ startup.mission }}"{% if startup.stats %}
-            , "stats_url": "{% if startup.stats_url %}{{ startup.stats_url }}{% else %}{{ startup.link | strip }}/stats{% endif %}"{% endif %}{% if startup.link %}
+            , "stats_url": "{% if startup.stats_url %}{{ startup.stats_url }}{% else %}{{ startup.link | strip }}/stats{% endif %}"{% endif %}
             {% if startup.budget_url %}
-            ,"budget_url": "{{ startup.budget_url }}"{% endif %}
+            ,"budget_url": "{{ startup.budget_url }}"{% endif %}{% if startup.link %}
             , "link": "{{ startup.link}}"{% endif %}{% if startup.repository %}
             , "repository": "{{ startup.repository}}"{% endif %}
             , "contact": "{{startup.contact}}"

--- a/api/v2.5/startups.json
+++ b/api/v2.5/startups.json
@@ -1,0 +1,71 @@
+---
+layout: null
+---
+
+{ "links":
+    { "self": "{{ site.url }}/startups" }
+, "data":
+    [
+    {% for startup in site.startups %}
+        { "id"        : "{{ startup.id | remove: '/startups/' }}"
+        , "type"      : "startup"
+        , "attributes":
+            { "name"  : "{{ startup.title }}"
+            , "pitch" : "{{ startup.mission }}"{% if startup.stats %}
+            , "stats_url": "{% if startup.stats_url %}{{ startup.stats_url }}{% else %}{{ startup.link | strip }}/stats{% endif %}"{% endif %}{% if startup.link %}
+            {% if startup.budget_url %}
+            ,"budget_url": "{{ startup.budget_url }}"{% endif %}
+            , "link": "{{ startup.link}}"{% endif %}{% if startup.repository %}
+            , "repository": "{{ startup.repository}}"{% endif %}
+            , "contact": "{{startup.contact}}"
+            , "content_url_encoded_markdown": "{{startup.content_url_encoded_markdown}}"
+            , "events": [
+                {% for event in startup.events %}
+                    { "name": "{{event.name}}", "date": "{{event.date}}", "comment": "{{event.comment}}"}{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+                ]
+            , "phases": [
+                {% for phase in startup.phases %}
+                    { "name": "{{phase.name}}", "start": "{{phase.start}}", "end": "{{phase.end}}"}{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+                ]
+            {% if startup.analyse_risques %}
+            , "analyse_risques": "{{ startup.analyse_risques}}"
+            { % endif %}
+            {% if startup.analyse_risques_url %}
+            , "analyse_risques_url": "{{ startup.analyse_risques_url}}"
+            { % endif %}
+            {% if startup.dashlord_url %}
+            , "dashlord_url": "{{ startup.dashlord_url}}"
+            { % endif %}
+            {% if startup.accessibility_status %}
+            , "accessibility_status": "{{ startup.accessibility_status}}"
+            { % endif %}
+            }
+        , "relationships":
+            { "incubator":
+                { "data": { "type": "incubator", "id": "{{ startup.incubator}}" }
+                }
+            }
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    ]
+, "included":
+    [
+    {% for incubator in site.incubators %}
+        { "id"        : "{{ incubator.id | remove:'/incubateurs/approche' }}"
+        , "type"      : "incubator"
+        , "attributes":
+            { "title"  : "{{ incubator.title }}"
+            , "owner"  : "{{ incubator.owner }}"
+            , "website": "{{ incubator.website }}"
+            , "github" : "{{ incubator.github }}"
+            , "contact": "{{ incubator.contact }}"
+            }
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    ]
+
+}

--- a/api/v2.5/startups.json
+++ b/api/v2.5/startups.json
@@ -31,16 +31,16 @@ layout: null
                 ]
             {% if startup.analyse_risques %}
             , "analyse_risques": "{{ startup.analyse_risques}}"
-            { % endif %}
+            {% endif %}
             {% if startup.analyse_risques_url %}
             , "analyse_risques_url": "{{ startup.analyse_risques_url}}"
-            { % endif %}
+            {% endif %}
             {% if startup.dashlord_url %}
             , "dashlord_url": "{{ startup.dashlord_url}}"
-            { % endif %}
+            {% endif %}
             {% if startup.accessibility_status %}
             , "accessibility_status": "{{ startup.accessibility_status}}"
-            { % endif %}
+            {% endif %}
             }
         , "relationships":
             { "incubator":

--- a/api/v2.5/startups_details.json
+++ b/api/v2.5/startups_details.json
@@ -1,0 +1,5 @@
+---
+layout: null
+---
+
+{% render_startups_api %}

--- a/rb/schema/startups.yml
+++ b/rb/schema/startups.yml
@@ -157,4 +157,17 @@ mapping:
             - entreprise
             - association
             - etablissement-scolaire 
-
+  "analyse_risques":
+    type:      bool
+  "analyse_risques_url":
+    type:      str
+  "dashlord_url":
+    type:      str 
+  "investigation_outputs_url":
+    type:      str
+  "accessibility_status":
+    type:      str
+    enum:
+     - totalement conforme
+     - partiellement conforme
+     - non conforme

--- a/rb/schema/startups.yml
+++ b/rb/schema/startups.yml
@@ -163,8 +163,6 @@ mapping:
     type:      str
   "dashlord_url":
     type:      str 
-  "investigation_outputs_url":
-    type:      str
   "accessibility_status":
     type:      str
     enum:


### PR DESCRIPTION
Je propose de rajouter 5 nouveaux champs dans les fiches startups, afin de :
- 🔎 améliorer et encourager la transparence des équipes sur un certain nombre de bonnes pratiques
- 📊 pouvoir valoriser ces infos dans Dashlord (qui peut maintenant [consommer l'API du site](https://github.com/betagouv/dashlord/pull/51))
- 📈 pouvoir mesurer l'impact de l'équipe "services transverses aux produits"

## Détail des nouveau champs

- `analyse_risques` est un booléen qui indique si l'équipe à réalisé un atelier d'analyse de risques agile
- `analyse_risques_url` permet de lier vers ladite analyse de risque (la bonne pratique est de la publier et de la tenir à jour)
- `dashlord_url` est un lien vers l'onglet Dashlord de la startup
- `investigation_outputs_url` est un lien vers les rendus de la phase d'investigation, pour encourager leur publication :)
- `accessibility_status` indique le statut d'accessibilité du service

Aucun de ces champs n'est obligatoire.

## TODO
- rajouter ces champs à l'API
- valoriser ces valeurs dans Dashlord
- calculer des indicateurs pour l'équipe produit via ces champs

WDYT ?