### PR TITLE
Transforme le champ d'accessibilité en champ select

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -128,9 +128,9 @@ collections:
         hint : >
           Le statut d'accessibilité de ton produit. Une valeur parmi "totalement conforme", "partiellement conforme", et "non conforme". Si tu ne sais pas remplir ce champs, indique "non conforme".
         name: accessibility_status
-        widget: string
-        collapsed: false
+        widget: "select"
         default: "non conforme"
+        options: ["non conforme", "partiellement conforme", "totalement conforme"]
         required: false
       - label: Évènements marquants
         name: events

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -126,7 +126,7 @@ collections:
         required: false
       - label: Statut d'accessibilité
         hint : >
-          Le statut d'accessibilité de ton produit. Une valeur parmi "totalement conforme", "partiellement conforme", et "non conforme". Si tu ne sais pas remplir ce champs, indique "non conforme".
+          Le statut d'accessibilité de ton produit. Une valeur parmi "totalement conforme", "partiellement conforme", et "non conforme". Si tu ne sais pas remplir ce champ, indique "non conforme".
         name: accessibility_status
         widget: "select"
         default: "non conforme"


### PR DESCRIPTION
## Détails

Sur la page netlify permettant aux startups d'État d'éditer leur fiche, changement du champ `accessibilité` de champ texte à champ de type "select"