### PR TITLE
fix: wrong field displayed for accessibility in se pages

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -98,7 +98,7 @@ Le suivi des bonnes pratiques de ce produit
 
 {% capture accessibilite %}
 {% if page.accessibility_status %}
-<li>Le statut d'accessibilité du produit est : <em>{{ page.investigation_outputs_url }}</em></li>
+<li>Le statut d'accessibilité du produit est : <em>{{ page.accessibility_status }}</em></li>
 {% elsif phase.status == 'acceleration' or phase.status == 'success' or phase.status == 'transfer' %}
 <li>Le statut d'accessibilité du produit est : <em>non-conforme</em></li>
 {% endif %}


### PR DESCRIPTION
Ce bug causait le mauvais affichage du statut d'accessibilité pour les SE l'ayant renseigné
<img width="554" alt="Screenshot 2022-04-19 at 11 56 48" src="https://user-images.githubusercontent.com/30295971/163979141-7790dbc6-59aa-412c-bb6d-19d123e201a1.png">
