### PR TITLE
Créer des pages "problèmes investigués"

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -10,6 +10,9 @@ nav:
   -
     label: Recrutement
     target: _pages/recrutement.md
+  -
+    label: Problèmes investigués
+    target: _pages/problems.md
 shortcuts:
   -
     label: Annuaire
@@ -23,3 +26,4 @@ shortcuts:
     label: Blog
     external: true
     url: https://blog.beta.gouv.fr
+  

--- a/_pages/problems.md
+++ b/_pages/problems.md
@@ -1,0 +1,7 @@
+---
+layout: problems
+title: Les investigations menées à beta
+permalink: /problemes/
+redirect_from:
+  - /problems
+---

--- a/rb/schema/problems.yml
+++ b/rb/schema/problems.yml
@@ -1,0 +1,126 @@
+type:       map
+mapping:
+  "title":
+    type:      str
+    required:  yes
+  "topic":
+    type:      str
+    required:  yes
+  "sponsors":
+    type:      seq
+    sequence:
+        - type:      str
+          enum:
+            - /organisations/ademe
+            - /organisations/acoss
+            - /organisations/agence-bio
+            - /organisations/anah
+            - /organisations/anct
+            - /organisations/ans
+            - /organisations/anssi
+            - /organisations/armees
+            - /organisations/ars-franche-comte
+            - /organisations/assemblee-nationale
+            - /organisations/bdf
+            - /organisations/c-comptes
+            - /organisations/cdc
+            - /organisations/cerema
+            - /organisations/cgdd
+            - /organisations/cma-haut-de-france
+            - /organisations/cnam
+            - /organisations/cnav
+            - /organisations/cnsa
+            - /organisations/departement-oise
+            - /organisations/departement-pas-de-calais
+            - /organisations/departement-var
+            - /organisations/dg-tresor
+            - /organisations/dgac
+            - /organisations/dgafp
+            - /organisations/dgal
+            - /organisations/dgaln
+            - /organisations/dgca
+            - /organisations/dgccrf
+            - /organisations/dgcs
+            - /organisations/dgddi
+            - /organisations/dge
+            - /organisations/dgeb
+            - /organisations/dgec
+            - /organisations/dgefp
+            - /organisations/dgesco
+            - /organisations/dgesip
+            - /organisations/dgfip
+            - /organisations/dgitm
+            - /organisations/dgos
+            - /organisations/dgpat
+            - /organisations/dgpr
+            - /organisations/dgs
+            - /organisations/dgt
+            - /organisations/dhup
+            - /organisations/dihal
+            - /organisations/dinum
+            - /organisations/ditp
+            - /organisations/djepva
+            - /organisations/dns
+            - /organisations/drieat
+            - /organisations/dsr
+            - /organisations/fnccr
+            - /organisations/hcc
+            - /organisations/igj
+            - /organisations/ign
+            - /organisations/igpn
+            - /organisations/inca
+            - /organisations/interieur
+            - /organisations/mc
+            - /organisations/mctrct
+            - /organisations/meae
+            - /organisations/mefr
+            - /organisations/menjs
+            - /organisations/mesr
+            - /organisations/mj
+            - /organisations/mtei
+            - /organisations/mtes
+            - /organisations/mtfp
+            - /organisations/nouvelle-caledonie
+            - /organisations/pole-emploi
+            - /organisations/sgdsn
+            - /organisations/shom
+            - /organisations/sndv
+            - /organisations/solidarite-sante
+            - /organisations/urssaf
+  "link":
+    type:      str
+  "contact":
+    type:      str
+    pattern:   /@/
+    required:  yes
+  "usertypes":
+    type:      seq
+    sequence:
+        - type:      str
+          enum:
+            - particulier
+            - etat
+            - collectivite-territoriale
+            - parlement
+            - entreprise
+            - association
+            - etablissement-scolaire 
+  "start":
+   type:       date
+  "end":
+   type:       date
+  "problems":
+    type:      seq
+    sequence:
+        - type:      str
+  "solutions":
+    type:      seq
+    sequence:
+        - type:      str
+  "se":
+   type: str
+  "ressource_links":
+    type:      seq
+    sequence:
+        - type:      str
+  


### PR DESCRIPTION
# Fiches "Problèmes Investigués"

## Pour quoi faire ?
- Créer une base de données ouverte des phases d'investigation menées dans le réseau beta.gouv
- Désengorger la pages /startups sur le site de beta.gouv.fr

## Comment ?
- Création d'une page recensant les "problèmes investigués"
- création d'une API beta.gouv.fr/api/problems.json