### PR TITLE
bundler: update bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,4 +107,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.0.1
+   2.3.12


### PR DESCRIPTION
Mise à jour de la version de Bundler; [l'image Docker de Jekyll utilise Ruby 3.1.1](https://hub.docker.com/layers/jekyll/jekyll/jekyll/latest/images/sha256-5776c8eed572003d9ec021767d725b6aa37226bebf4a5219049c063ff8b698ef?context=explore) qui elle-même [inclue Bundler 2.3.1](https://github.com/ruby/ruby/pull/5543).
