### PR TITLE
jobs: suppression de la capitalisation des titres d'offres

### DIFF
--- a/_includes/card-job.html
+++ b/_includes/card-job.html
@@ -27,7 +27,7 @@
     </div>
 
     <h2 class="fr-card__title">
-      <a class="fr-card__link" href="{{ job.url }}">{{ job.roles | capitalize }}</a>
+      <a class="fr-card__link" href="{{ job.url }}">{{ job.roles }}</a>
     </h2>
 
     <p class="fr-card__desc">{{ job.excerpt | strip_html | truncate: 260 }}</p>

--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -6,7 +6,7 @@ layout: default
 
 {% include hero-page.html title=page.title %}
 
-<section class="fr-py-6w cards">
+<section class="cards">
   <div class="fr-container">
     <div class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col-md-9 fr-col-sm-12 fr-col-lg-9">
@@ -23,11 +23,11 @@ layout: default
       </div>
       <div class="fr-col-md-3 fr-col-lg-3 fr-col-sm-12">
         <div class="fr-card fr-card--no-arrow job-section-blue" style="height: inherit;">
-          <div class="fr-card__body">  
+          <div class="fr-card__body">
             <div class="job-team-animation-container">
-              <object data="/assets/home/intra_back.svg" class="job-team-animation-background"></object>    
+              <object data="/assets/home/intra_back.svg" class="job-team-animation-background"></object>
               <object data="/assets/home/intra.svg" class="job-team-animation-foreground"></object>
-            </div>   
+            </div>
             <h3 class="fr-card__title">
               Vous êtes agent public et vous souhaitez rejoindre beta.gouv.fr ?
             </h3>
@@ -35,9 +35,9 @@ layout: default
           </div>
         </div>
           <div class="fr-card fr-card--no-arrow job-section-blue" style="height: inherit;">
-          <div class="fr-card__body">  
+          <div class="fr-card__body">
             <h3 class="fr-card__title">
-              Vous souhaitez candidater à une offre&nbsp;? 
+              Vous souhaitez candidater à une offre&nbsp;?
             </h3>
               <a class="fr-btn fr-btn--sm fr-enlarge-link fr-btn--secondary button-white-border" href="https://doc.incubateur.net/communaute/travailler-a-beta-gouv/actions-transverses/guide-pour-les-candidat-e-s">Découvrez notre guide pour les candidat(e)s</a>
           </div>


### PR DESCRIPTION
Pas nécessaire et empêche certaines annonces d'avoir la bonne
capitalisation, i.e "Développeur Ruby on Rails".

Aussi rejet d'un padding pas nécessaire sur le layout des jobs.

## Avant
![Capture d’écran 2022-05-10 à 14 09 51](https://user-images.githubusercontent.com/107635/167625056-800da5a4-cd75-4d84-8004-202efeccee14.png)

## Après
![Capture d’écran 2022-05-10 à 14 09 50](https://user-images.githubusercontent.com/107635/167625141-83b0b6ff-5bfe-4f04-8bf1-130a22d32d81.png)

