### PR TITLE
home : remove target blank if not necessary and add title info if target blank

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,12 +25,16 @@
           </div>
         </div>
 
-        <div class="fr-header__tools">    
+        <div class="fr-header__tools">
           <div class="fr-header__tools-links">
             <ul class="fr-links-group">
               {% for item in site.data.menu.shortcuts %}
               <li class="fr-shortcuts__item">
-                <a class="fr-link {% if item.external %}fr-fi-external-link-line fr-link--icon-right{% endif %}" href="{{ item.url }}" title="{{ item.label }}" target="_blank" rel="noopener">{{ item.label }}</a>
+                {% if item.external == true %}
+                  <a class="fr-link fr-fi-external-link-line fr-link--icon-right" href="{{ item.url }}" title="{{ item.label }} - Nouvelle fenêtre" target="_blank" rel="noopener">{{ item.label }}</a>
+                {% else %}
+                  <a class="fr-link" href="{{ item.url }}" title="{{ item.label }}">{{ item.label }}</a>
+                {% endif %}
               </li>
               {% endfor %}
             </ul>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -215,7 +215,7 @@ layout: default
       <h3>Gardons le contact</h3>
       <p>Recevez les actualités de beta.gouv, tous les mois</p>
       <div class="fr-input-group">
-        <button class="fr-btn" type="submit" name="subscribe" id="form-submit">S’inscrire</button>
+        <button class="fr-btn" type="submit" name="subscribe" id="form-submit" title="S'inscrire aux actualités - Nouvelle fenêtre">S’inscrire</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
Si c'est possible ne pas utiliser de target blank pour les liens.
Si on ne peut pas faire autrement, il faut l'indiquer dans une balise "title".