### PR TITLE
add skip links for quick access

### DIFF
--- a/_includes/skip_links.html
+++ b/_includes/skip_links.html
@@ -1,0 +1,12 @@
+<div class="fr-skiplinks">
+  <nav class="fr-container" role="navigation" aria-label="Accès rapide">
+      <ul class="fr-skiplinks__list">
+          <li>
+              <a class="fr-link" href="#contenu">Accéder au contenu</a>
+          </li>
+          <li>
+              <a class="fr-link" href="#footer">Accéder au pied de page</a>
+          </li>
+      </ul>
+  </nav>
+</div>

--- a/_layouts/dashboard.html
+++ b/_layouts/dashboard.html
@@ -8,48 +8,46 @@ layout: default
 
 {% include hero-page.html title=page.title %}
 
-<main>
-    <section class="fr-py-6w">
-        <div class="fr-container">
-            <div class="text-center fr-mb-2w">
-                <a class="button" href="/api/v1.7/startups.csv">Télécharger au format .csv</a>
-            </div>
-
-            {% assign phases = site.phases | sort: 'order' %}
-            <table>
-                <colgroup>
-                    <col style="width: 10%;">
-                    <col style="width: 40%;">
-                    <col>
-                    <col>
-                    <col>
-                 </colgroup>
-                <tbody>
-                    <tr>
-                        <th>Nom</th>
-                        <th>Objectif</th>
-                        <th>Phase actuelle</th>
-                        <th>Incubateur</th>
-                        <th>Date de début</th>
-                    </tr>
-                    {% for phase in phases %}
-                        {% assign startups = site.startups | where_phase: phase.status %}
-                        {% for startup in startups %}
-                            <tr>
-                                <td>{{ startup.title }}</td>
-                                <td>{{ startup.mission }}</td>
-                                <td>{{ phase.label }}</td>
-
-                                {% capture incubator_id %}/incubators/{{ startup.incubator }}{% endcapture %}
-                                {% assign incubator = site.incubators | where:'id', incubator_id | first %}
-                                <td>{{ incubator.title }}</td>
-
-                                <td>{{ startup.phases.first.start |  date: '%d/%m/%Y' }}</td>
-                            </tr>
-                        {% endfor %}
-                    {% endfor %}
-                </tbody>
-            </table>
+<section class="fr-py-6w">
+    <div class="fr-container">
+        <div class="text-center fr-mb-2w">
+            <a class="button" href="/api/v1.7/startups.csv">Télécharger au format .csv</a>
         </div>
-    </section>
-</main>
+
+        {% assign phases = site.phases | sort: 'order' %}
+        <table>
+            <colgroup>
+                <col style="width: 10%;">
+                <col style="width: 40%;">
+                <col>
+                <col>
+                <col>
+              </colgroup>
+            <tbody>
+                <tr>
+                    <th>Nom</th>
+                    <th>Objectif</th>
+                    <th>Phase actuelle</th>
+                    <th>Incubateur</th>
+                    <th>Date de début</th>
+                </tr>
+                {% for phase in phases %}
+                    {% assign startups = site.startups | where_phase: phase.status %}
+                    {% for startup in startups %}
+                        <tr>
+                            <td>{{ startup.title }}</td>
+                            <td>{{ startup.mission }}</td>
+                            <td>{{ phase.label }}</td>
+
+                            {% capture incubator_id %}/incubators/{{ startup.incubator }}{% endcapture %}
+                            {% assign incubator = site.incubators | where:'id', incubator_id | first %}
+                            <td>{{ incubator.title }}</td>
+
+                            <td>{{ startup.phases.first.start |  date: '%d/%m/%Y' }}</td>
+                        </tr>
+                    {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,6 +52,7 @@
         </symbol>
       </defs>
     </svg>
+    {% include skip_links.html %}
     {% include header.html %}
 
     {% if page.breadcrumbs %}
@@ -73,7 +74,9 @@
       </nav>
     </div>
     {% endif %}
-    {{ content }}
+    <div id="contenu">
+      {{ content }}
+    </div>
     {% include footer.html %}
     {% include script.html %}
   </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -74,9 +74,9 @@
       </nav>
     </div>
     {% endif %}
-    <div id="contenu">
+    <main id="contenu">
       {{ content }}
-    </div>
+    </main>
     {% include footer.html %}
     {% include script.html %}
   </body>

--- a/_layouts/startups.html
+++ b/_layouts/startups.html
@@ -88,90 +88,87 @@ layout: default
             {% unless forloop.last %},{% endunless %}
         {% endfor %}
     ];
-</script>   
-<main>
-    <section class="filters sticky">
-        <div class="fr-container">
-            <select class="fr-select" id="select-incubateur">
-                <option value="">Tous les incubateurs</option> 
-            </select>
-            <select class="fr-select" id="select-usertypes">
-                <option value="">Tous les types d'usagers</option>
-            </select>
-            <select class="fr-select" id="select-phase">
-                <option>Aller à une phase</option>
-                {% for phase in phases_with_stopped %}
-                    <option value="{{ phase.status }}" id="{{phase.status}}-option">{{ phase.label }}</option>
-                {% endfor %}
-            </select>
-            <div class="fr-search-bar" id="search-input">
-                <label class="fr-label" for="search-input-input">Label de la barre de recherche</label>
-                <input class="fr-input" placeholder="Rechercher" type="search" id="search-input-input" name="search-input-input">
-                <button class="fr-btn" title="Rechercher" id="search-input-button">
-                        Rechercher
-                </button>
-                <ul id="results-container"></ul>
-            </div>
+</script>
+<section class="filters sticky">
+    <div class="fr-container">
+        <select class="fr-select" id="select-incubateur">
+            <option value="">Tous les incubateurs</option>
+        </select>
+        <select class="fr-select" id="select-usertypes">
+            <option value="">Tous les types d'usagers</option>
+        </select>
+        <select class="fr-select" id="select-phase">
+            <option>Aller à une phase</option>
+            {% for phase in phases_with_stopped %}
+                <option value="{{ phase.status }}" id="{{phase.status}}-option">{{ phase.label }}</option>
+            {% endfor %}
+        </select>
+        <div class="fr-search-bar" id="search-input">
+            <label class="fr-label" for="search-input-input">Label de la barre de recherche</label>
+            <input class="fr-input" placeholder="Rechercher" type="search" id="search-input-input" name="search-input-input">
+            <button class="fr-btn" title="Rechercher" id="search-input-button">
+                    Rechercher
+            </button>
+            <ul id="results-container"></ul>
         </div>
-    </section>
-    {% for incubator in incubators %}
-    {% assign incubator_id = incubator.id | remove: '/incubators/' %}
-    {% assign organisation = site.organisations  | where: 'id', incubator.owner | first %}
+    </div>
+</section>
+{% for incubator in incubators %}
+{% assign incubator_id = incubator.id | remove: '/incubators/' %}
+{% assign organisation = site.organisations  | where: 'id', incubator.owner | first %}
 
-    <section id="{{ incubator_id }}" class="fr-py-6w incubator-header fr-scheme-soft-blue-soft" style="display: none;">
-        <div class="fr-container">
-            <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-1 incubator-logo">
-                    <img src="../img/incubators/{{ incubator.logo }}" alt="Logo de {{ incubator.title }}">
-                </div>
-                <div class="fr-col">
-                    <div>
-                        <h1 class="fr-card__title">{{ incubator.title }}</h1>
-                        <p class="h1-card__title-subtitle">{{ organisation.name }}</p>
-                        <div class="markdown">{{ incubator.content }}</div>
-                    </div>
+<section id="{{ incubator_id }}" class="fr-py-6w incubator-header fr-scheme-soft-blue-soft" style="display: none;">
+    <div class="fr-container">
+        <div class="fr-grid-row fr-grid-row--gutters">
+            <div class="fr-col-1 incubator-logo">
+                <img src="../img/incubators/{{ incubator.logo }}" alt="Logo de {{ incubator.title }}">
+            </div>
+            <div class="fr-col">
+                <div>
+                    <h1 class="fr-card__title">{{ incubator.title }}</h1>
+                    <p class="h1-card__title-subtitle">{{ organisation.name }}</p>
+                    <div class="markdown">{{ incubator.content }}</div>
                 </div>
             </div>
         </div>
-    </section>
-    {% endfor %}
+    </div>
+</section>
+{% endfor %}
 
-    <div class="fr-container fr-py-6w">
-        <div id="no-data-message" style="display: none;">
-            <p>Il n'y a pas de résultats qui correspondent à ces filtres</p>
-        </div>
-        {% assign phases = site.phases | sort: 'order' %}
-        {% for phase in phases %}
-            {% assign counter_target = phase.id | remove: "/phases/" %}
-            {% assign counter = site.startups | where_phase: counter_target | size %}
-            {% assign plural = "" %}
-            {% if counter > 1 %}
-                {% assign plural = "s" %}
+<div class="fr-container fr-py-6w">
+    <div id="no-data-message" style="display: none;">
+        <p>Il n'y a pas de résultats qui correspondent à ces filtres</p>
+    </div>
+    {% assign phases = site.phases | sort: 'order' %}
+    {% for phase in phases %}
+        {% assign counter_target = phase.id | remove: "/phases/" %}
+        {% assign counter = site.startups | where_phase: counter_target | size %}
+        {% assign plural = "" %}
+        {% if counter > 1 %}
+            {% assign plural = "s" %}
+        {% endif %}
+
+        <div id="{{ phase.status }}" class="fr-container-fluid fr-my-6w">
+            {% if phase.status == 'success' %}
+                <h1 class="phase-title">Nos <em><span class="phase-label">{{ phase.label | downcase }}s</span></em></h1>
+            {% elsif phase.status == 'alumni' %}
+                <h1 class="phase-title">Nos <em>{{ phase.label | downcase }}</em></h1>
+            {% else %}
+                <h1 class="phase-title"><em><span class="phase-counter">{{ counter }}</span></em> <span class="phase-label">{{ phase.type_label }}{{ plural }}</span> en
+                <em>{{ phase.label | downcase }}</em></h1>
             {% endif %}
 
-            <div id="{{ phase.status }}" class="fr-container-fluid fr-my-6w">
-                {% if phase.status == 'success' %}
-                    <h1 class="phase-title">Nos <em><span class="phase-label">{{ phase.label | downcase }}s</span></em></h1>
-                {% elsif phase.status == 'alumni' %}
-                    <h1 class="phase-title">Nos <em>{{ phase.label | downcase }}</em></h1>
-                {% else %}
-                    <h1 class="phase-title"><em><span class="phase-counter">{{ counter }}</span></em> <span class="phase-label">{{ phase.type_label }}{{ plural }}</span> en
-                    <em>{{ phase.label | downcase }}</em></h1>
-                {% endif %}
+            <p class="phase-description">{{ phase.short_description }}.</p>
 
-                <p class="phase-description">{{ phase.short_description }}.</p>
-
-                <div class="fr-grid-row fr-grid-row--gutters startups">
-                    {% assign startups = site.startups | where_phase: phase.status %}
-                    {% for startup in startups %}
-                        {% include card-startup.html startup = startup %}
-                    {% endfor %}
-                </div>
+            <div class="fr-grid-row fr-grid-row--gutters startups">
+                {% assign startups = site.startups | where_phase: phase.status %}
+                {% for startup in startups %}
+                    {% include card-startup.html startup = startup %}
+                {% endfor %}
             </div>
-        {% endfor %}
-    </div>
-</main>
-
+        </div>
+    {% endfor %}
+</div>
 
 <!-- Filtres -->
 <script>


### PR DESCRIPTION
J'ai ajouté les liens d’évitement du DSFR qui permettent aux utilisateurs qui naviguent avec le clavier d’accéder plus rapidement à des zones précises de la page.
Je me suis inspirée du site gouvernement.fr en ajoutant les verbes "accéder".
Et j'ai ajouté des liens rapides uniquement vers le contenu et le pied de page. Je n'ai pas ajouté vers le menu comme sur design.numerique.gouv.fr car en version tablet/responsive, le menu n'est plus placé au mm endroit donc je ne sais pas comment on est censé gérer ça.

Pour tester : faire tab à l'arrivée sur le site.
<img width="1439" alt="Capture d’écran 2022-05-23 à 15 56 39" src="https://user-images.githubusercontent.com/6756627/169835772-6085e267-a84b-47bc-bcfd-ee9594763ed7.png">

