### PR TITLE
add newsletter in footer and remove from other pages

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,19 +5,28 @@
 <div class="fr-follow">
   <div class="fr-container">
     <div class="fr-grid-row">
-      <div class="fr-col-12">
+      <div class="fr-col-12 fr-col-md-8">
+        <div class="fr-follow__newsletter">
+          <div>
+            <h2 class="fr-h5 fr-follow__title">Gardons le contact</h2>
+            <p class="fr-text--sm fr-follow__desc">Recevez les actualités de beta.gouv, tous les mois.</p>
+            <form method="post" target="_blank" action="https://981c5932.sibforms.com/serve/MUIEAED7q5La6zVwcMrAI5cwJB2EZmeOZVHfadIeHA7u9YyGUb9FB0MqprJ1A4DbWnpORGiPSZA4yxdpLFnWbjSvsFFgYNTtd7A54LhPxK3Zg2jaB_qK-b5Sm6aZ2M6kV1nO2mpJW0KcFGIMb5KbirWUxg8CJsQJUp_AJ6ARN5PSdFNxQpzVAPXKMNs1Z7n9lgK9bMoL9fFVP_Wx" id="newsletter">
+              <button class="fr-btn fr-btn--icon-left fr-fi-external-link-line" type="submit" name="subscribe" id="form-submit" title="S'inscrire aux actualités - Nouvelle fenêtre">S’inscrire</button>
+            </form>
+            </form>
+          </div>
+        </div>
+      </div>
+      <div class="fr-col-12 fr-col-md-4">
         <div class="fr-follow__social">
-          <p class="fr-h5">Suivez-nous
-            <br> sur les réseaux sociaux
-          </p>
+          <h2 class="fr-h5 fr-mb-3v fr-mb-3v">Suivez-nous<br> sur les réseaux sociaux</h2>
           <ul class="fr-btns-group fr-btns-group--lg">
             {% for item in site.data.footer.social %}
               <li>
                 <a class="fr-icon-{{ item.icon }}-fill fr-btn" href="{{ item.url }}" target="_blank" title="Profil {{ item.icon | capitalize }} de BetaGouv - nouvelle fenêtre">
-                  {{ item.icon }}
-                </a>
+                  {{ item.icon }}</a>
               </li>
-            {% endfor %}
+              {% endfor %}
           </ul>
         </div>
       </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,19 +7,16 @@
     <div class="fr-grid-row">
       <div class="fr-col-12 fr-col-md-8">
         <div class="fr-follow__newsletter">
-          <div>
-            <h2 class="fr-h5 fr-follow__title">Gardons le contact</h2>
-            <p class="fr-text--sm fr-follow__desc">Recevez les actualités de beta.gouv, tous les mois.</p>
-            <form method="post" target="_blank" action="https://981c5932.sibforms.com/serve/MUIEAED7q5La6zVwcMrAI5cwJB2EZmeOZVHfadIeHA7u9YyGUb9FB0MqprJ1A4DbWnpORGiPSZA4yxdpLFnWbjSvsFFgYNTtd7A54LhPxK3Zg2jaB_qK-b5Sm6aZ2M6kV1nO2mpJW0KcFGIMb5KbirWUxg8CJsQJUp_AJ6ARN5PSdFNxQpzVAPXKMNs1Z7n9lgK9bMoL9fFVP_Wx" id="newsletter">
-              <button class="fr-btn fr-btn--icon-left fr-fi-external-link-line" type="submit" name="subscribe" id="form-submit" title="S'inscrire aux actualités - Nouvelle fenêtre">S’inscrire</button>
-            </form>
-            </form>
-          </div>
+          <h2 class="fr-h5">Gardons le contact</h2>
+          <p class="fr-text--sm">Recevez les actualités de beta.gouv, tous les mois.</p>
+          <form method="post" target="_blank" action="https://981c5932.sibforms.com/serve/MUIEAED7q5La6zVwcMrAI5cwJB2EZmeOZVHfadIeHA7u9YyGUb9FB0MqprJ1A4DbWnpORGiPSZA4yxdpLFnWbjSvsFFgYNTtd7A54LhPxK3Zg2jaB_qK-b5Sm6aZ2M6kV1nO2mpJW0KcFGIMb5KbirWUxg8CJsQJUp_AJ6ARN5PSdFNxQpzVAPXKMNs1Z7n9lgK9bMoL9fFVP_Wx" id="newsletter">
+            <button class="fr-btn fr-btn--icon-left fr-fi-external-link-line" type="submit" name="subscribe" id="form-submit" title="S'inscrire aux actualités - Nouvelle fenêtre">S’inscrire</button>
+          </form>
         </div>
       </div>
       <div class="fr-col-12 fr-col-md-4">
         <div class="fr-follow__social">
-          <h2 class="fr-h5 fr-mb-3v fr-mb-3v">Suivez-nous<br> sur les réseaux sociaux</h2>
+          <h2 class="fr-h5">Suivez-nous<br> sur les réseaux sociaux</h2>
           <ul class="fr-btns-group fr-btns-group--lg">
             {% for item in site.data.footer.social %}
               <li>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -208,18 +208,7 @@ layout: default
     </div>
   </div>
 </section>
-<hr>
-<section class="fr-py-6w newsletter">
-  <div class="fr-container">
-    <form method="post" target="_blank" action="https://981c5932.sibforms.com/serve/MUIEAED7q5La6zVwcMrAI5cwJB2EZmeOZVHfadIeHA7u9YyGUb9FB0MqprJ1A4DbWnpORGiPSZA4yxdpLFnWbjSvsFFgYNTtd7A54LhPxK3Zg2jaB_qK-b5Sm6aZ2M6kV1nO2mpJW0KcFGIMb5KbirWUxg8CJsQJUp_AJ6ARN5PSdFNxQpzVAPXKMNs1Z7n9lgK9bMoL9fFVP_Wx" id="newsletter">
-      <h3>Gardons le contact</h3>
-      <p>Recevez les actualités de beta.gouv, tous les mois</p>
-      <div class="fr-input-group">
-        <button class="fr-btn" type="submit" name="subscribe" id="form-submit" title="S'inscrire aux actualités - Nouvelle fenêtre">S’inscrire</button>
-      </div>
-    </form>
-  </div>
-</section>
+
 <script type="text/javascript">
   var hand1 = document.getElementById('hero-anim-hand-1');
   var hand2 = document.getElementById('hero-anim-hand-2');

--- a/_layouts/lpintra.html
+++ b/_layouts/lpintra.html
@@ -9,9 +9,9 @@ layout: default
     <div class="fr-grid-row fr-grid-row--gutters fr-py-6w">
       <div class="fr-col fr-col-12 fr-col-md-6">
         <h1>Votre expérience est précieuse</h1>
-        <h2>
-          <span class="section-highlight">Vous êtes agent public ?</span>
-          <br>Aidez-nous à résoudre les problèmes des usagers et des agents.</h2>
+        <h2>        <span class="fr-enlarge-link section-highlight">
+          Vous êtes agent public ?
+      </span><br>Aidez-nous à résoudre les problèmes des usagers et des agents.</h2>
       <a
         class="fr-btn fr-btn--md fr-enlarge-link fr-btn--secondary button-white fr-mt-2w"
         href="/devenir-intrapreneur/decouvrir-le-role-d-intrapreneur">Découvrir le rôle d'intra</a>
@@ -72,19 +72,14 @@ layout: default
         <div class="fr-col-12 fr-col-md-4">
           <div class="fr-card fr-card--no-arrow card-feature">
             <div class="fr-card__body">
-              <div class="fr-card__content">
-                <h3 class="fr-card__title">
-                  Communauté
-                </h3>
-                <!-- <p class="fr-card__detail">{{ startup.owner | strip_html }}</p> -->
-                <p class="fr-card__desc">Rejoignez une communauté en croissance qui construit les services publics numériques de demain au sein d’un réseau d’incubateurs publics partageant les mêmes valeurs.</p>
+              <div class="lpintra-image-container">
+                <object data="/assets/images/intra/communaute.svg"></object>
               </div>
-              <div class="fr-card__header">
-                <div class="lpintra-image-container">
-                  <object data="/assets/images/intra/communaute.svg"></object>
-                </div>
-
-              </div>
+              <h3 class="fr-card__title">
+                Communauté
+              </h3>
+              <!-- <p class="fr-card__detail">{{ startup.owner | strip_html }}</p> -->
+              <p class="fr-card__desc">Rejoignez une communauté en croissance qui construit les services publics numériques de demain au sein d’un réseau d’incubateurs publics partageant les mêmes valeurs.</p>
             </div>
           </div>
         </div>
@@ -120,7 +115,7 @@ layout: default
         </div>
       </div>
       <div class="fr-grid-row fr-grid-row--center fr-grid-row--gutters startups fr-py-6w">
-        <a class="fr-btn fr-btn--md button-white-border fr-enlarge-link"
+        <a class="fr-btn fr-btn--md button-white-border fr-btn--secondary fr-enlarge-link"
           href="/communaute">Découvrir la communauté</a>
       </div>
     </div>
@@ -257,26 +252,4 @@ layout: default
           href="https://blog.beta.gouv.fr/">Plus de témoignages</a>
       </div>
     </div>
-</section>
-<hr>
-<section class="fr-py-6w newsletter">
-  <div class="fr-container">
-    <form method="post" action="https://app.mailjet.com/widget/iframe/1O2v/9ud" id="newsletter">
-      <h4>Gardons le contact</h4>
-      <p>Recevez les actualités de beta.gouv, tous les mois</p>
-
-      <input type="hidden" id="csrf_token" name="csrf_token" value="MmE2NTZkNWQ0MGQ0Y2IzOWQyZTllOWUxZGI2OWJhMTM2OTJhMDRjNzJjYjM5NWQ4MTRkM2UwNmRlYzBjM2RiYg==">
-      <div class="fr-input-group">
-        <input required=""
-          class="fr-input"
-          type="email"
-          autocomplete="on"
-          id="subscribe-email"
-          name="w-field-field-36469-172104-430683-email"
-          placeholder="votre adresse e-mail" />
-        <button class="fr-btn" type="submit" name="subscribe" id="form-submit">S’inscrire</button>
-
-      </div>
-    </form>
-  </div>
 </section>

--- a/assets/main.css
+++ b/assets/main.css
@@ -564,13 +564,8 @@ h2.phase-title em {
 
 /* END SECTION CLASS */
 
-#newsletter {
-  text-align: center;
-}
-
-#newsletter input {
-  display: inline-block;
-  width: auto;
+form[target="_blank"]::after {
+  display: none;
 }
 
 .bg-white {


### PR DESCRIPTION
J'ai ajouté le composant newsletter dans le footer et retiré celui des autres pages.
Il y a eu une discussion sur le Mattermost pour etre bien sur duquel prendre : SendinBlue VS Mailjet (sur la page intra qui était un oubli) et qu'on soit ok sur le fait de generaliser la newsletter à toutes les pages.

**Newsletter dans le footer :** 
<img width="1378" alt="Capture d’écran 2022-06-10 à 12 38 03" src="https://user-images.githubusercontent.com/6756627/173069704-da0535ca-6263-41b3-97ae-5dd1f2358aee.png">


