### PR TITLE
brigade: add a page title

### DIFF
--- a/_layouts/brigade.html
+++ b/_layouts/brigade.html
@@ -16,9 +16,6 @@ site.lang | default: "fr" -%}
 
 {%- assign authors = site.authors | where_exp: "author", "brigade_fullnames contains author.fullname" -%}
 
-{%- include hero-page.html title=page.title -%}
-
-
 <section class="section-blue section-main">
   <div class="fr-container">
     <div class="fr-grid-row fr-grid-row--gutters fr-py-6w">

--- a/_pages/brigade.md
+++ b/_pages/brigade.md
@@ -1,4 +1,5 @@
 ---
 layout: brigade
 permalink: /brigade/
+title: La Brigade de beta.gouv
 ---


### PR DESCRIPTION
Aucun changement visuel, juste le titre de la page qui passe de `beta.gouv.fr` à `La Brigade de beta.gouv – beta.gouv.fr`