### PR TITLE
remove irrelevant link a11y

### DIFF
--- a/_pages/approche.md
+++ b/_pages/approche.md
@@ -91,7 +91,7 @@ title: Découvrir le programme
          </p>
          <div class="fr-mb-4w fr-p-1w fr-col-md-6 fr-col-sm-12 fr-mt-2w section-grey" >
             <span aria-hidden="true">📅</span> Pendant <b>1 à 2 mois </b><br>
-            <span aria-hidden="true">✋</span> <a href="/devenir-intrapreneur">L’intra</a> accompagné d’un ou d’une coach
+            <span aria-hidden="true">✋</span> L’intra accompagné d’un ou d’une coach
          </div>
          <p>Décideur public, vous voulez lancer une investigation avec nous?</p>
         <div class="fr-btns-group fr-btns-group--inline">
@@ -127,7 +127,7 @@ title: Découvrir le programme
          </p>
          <div class="fr-mb-4w fr-p-1w fr-col-md-8 fr-col-sm-12 fr-mt-2w section-grey">
             <span aria-hidden="true">📅</span> Pendant <b>18 à 32 mois</b><br>
-            <span aria-hidden="true">✋</span> Avec <a href="/devenir-intrapreneur">l’intra</a>, son ou sa coach et une équipe d’experts
+            <span aria-hidden="true">✋</span> L’intra, son ou sa coach et une équipe d’experts
          </div>
          <p>Décideur public, vous voulez réaliser un service public numérique ?</p>
          <div class="fr-btns-group fr-btns-group--inline">
@@ -163,7 +163,7 @@ title: Découvrir le programme
 const nousecrireinvestigation = document.querySelector('#btn-nous-ecrire-investigation')
 const nousecrire = document.querySelector('#btn-nous-ecrire')
 const decouvririnvestigation = document.querySelector('#btn-decouvrir-investigation')
-const decouvrirconstruction = document.querySelector('#btn-decouvrir-construction') 
+const decouvrirconstruction = document.querySelector('#btn-decouvrir-construction')
 nousecrireinvestigation.addEventListener('click', function () {
       _paq.push(['trackEvent', 'conversion', 'Click nous ecrire'])
     })


### PR DESCRIPTION
J'ai retiré les liens "L'intra" pour résoudre 2 tickets dans l'accessibilité :
- "il n'y a pas de pieges dans la navigation au clavier" (ces liens arrivent un peu comme un cheveux sur la soupe)
- les actions sont explicites (il n'y a pas de verbe de type "Decouvrir le role de l'intra")