### PR TITLE
fix title order and remove not DSFR class for styling title

### DIFF
--- a/_pages/approche.md
+++ b/_pages/approche.md
@@ -25,14 +25,14 @@ title: Découvrir le programme
    </div>
 </div>
 <div class="fr-container section-grey fr-py-6w">
-   <h3 class="fr-mb-4w">Notre fonctionnement</h3>
+   <h2 class="fr-mb-4w">Notre fonctionnement</h2>
    <div class="fr-grid-row  fr-grid-row--gutters startups">
       <div class="fr-col fr-col-12 fr-col-md-3"  >
       <div class="fr-tile fr-enlarge__link">
       <div class="fr-tile__body">
-            <h4 class="fr-tile__title">
+            <h3 class="fr-tile__title">
                Améliorer de l'intérieur
-            </h4>
+            </h3>
             <p class="fr-tile__desc">En formant et faisant équipe avec des agents publics "intrapreneurs".</p>
          </div>
       </div>
@@ -40,9 +40,9 @@ title: Découvrir le programme
       <div class="fr-col fr-col-12 fr-col-md-3" >
          <div class="fr-tile fr-enlarge__link">
             <div class="fr-tile__body">
-            <h4 class="fr-tile__title">
+            <h3 class="fr-tile__title">
                Des jalons tous les 6 mois
-            </h4>
+            </h3>
             <p class="fr-tile__desc">Pour faire le point sur l’impact du produit, le continuer ou l’arrêter.</p>
             </div>
          </div>
@@ -50,9 +50,9 @@ title: Découvrir le programme
       <div class="fr-col fr-col-12 fr-col-md-3" >
          <div class="fr-tile fr-enlarge__link">
             <div class="fr-tile__body">
-            <h4 class="fr-tile__title">
+            <h3 class="fr-tile__title">
                L'approche "Startup d'Etat"
-            </h4>
+            </h3>
             <p class="fr-tile__desc">Un premier produit au contact des utilisateurs le plus vite possible.</p>
             </div>
          </div>
@@ -60,9 +60,9 @@ title: Découvrir le programme
       <div class="fr-col fr-col-12 fr-col-md-3" >
          <div class="fr-tile fr-enlarge__link">
             <div class="fr-tile__body">
-            <h4 class="fr-tile__title">
+            <h3 class="fr-tile__title">
                Un manifeste
-            </h4>
+            </h3>
             <p class="fr-tile__desc">Pour déterminer notre façon de travailler ensemble.
             <br>
             <a href="https://beta.gouv.fr/approche/manifeste">Lire notre manifeste</a></p>
@@ -82,10 +82,10 @@ title: Découvrir le programme
           />
       </div>
       <div class="fr-col-md-8 fr-px-4w fr-col-12">
-         <span><b>L’Investigation</b></span>
-         <h3>
+         <h3 class="fr-text--md fr-mb-0">L’Investigation</h3>
+         <h4>
             Identifier le problème à résoudre
-         </h3>
+         </h4>
          <p>
           Valider que le problème peut être résolu par le numérique  en rencontrant des utilisateurs pour qualifier le problème et imaginer des ébauches de solutions
          </p>
@@ -109,19 +109,19 @@ title: Découvrir le programme
           />
       </div>
       <div class="fr-col-md-8 fr-px-4w fr-col-12">
-         <span><b>La Start-up d’Etat</b></span>
-         <h3>
+         <h3 class="fr-text--md fr-mb-0">La Start-up d’Etat</h3>
+         <h4>
             Réaliser un service public numérique
-         </h3>
-         <h4 class="decorated fr-mt-4w">La phase de construction</h4>
+         </h4>
+         <h5 class="fr-text--md fr-mb-0">La phase de construction</h5>
          <p>
             Constituer son équipe et développer son produit en produisant la première version de la solution sur un terrain d’expérimentation.
          </p>
-         <h4 class="decorated">La phase d’accélération</h4>
+         <h5 class="fr-text--md fr-mb-0">La phase d’accélération</h5>
          <p>
             Avoir un produit fini déployé au niveau national.
          </p>
-         <h4 class="decorated">La phase de transfert</h4>
+         <h5 class="fr-text--md fr-mb-0">La phase de transfert</h5>
          <p>
             Créer les conditions de la reprise en assurant la pérennité du projet au sein de son administration d‘origine.
          </p>
@@ -146,7 +146,7 @@ title: Découvrir le programme
         />
    </div>
    <div class="fr-col-md-8 fr-px-4w fr-col-12">
-      <span><b>La formation des agents publics</b></span>
+      <h2 class="fr-text--md fr-mb-0">La formation des agents publics</h2>
       <h3>
          Passer une journée à beta.gouv
       </h3>
@@ -163,7 +163,7 @@ title: Découvrir le programme
 const nousecrireinvestigation = document.querySelector('#btn-nous-ecrire-investigation')
 const nousecrire = document.querySelector('#btn-nous-ecrire')
 const decouvririnvestigation = document.querySelector('#btn-decouvrir-investigation')
-const decouvrirconstruction = document.querySelector('#btn-decouvrir-construction') 
+const decouvrirconstruction = document.querySelector('#btn-decouvrir-construction')
 nousecrireinvestigation.addEventListener('click', function () {
       _paq.push(['trackEvent', 'conversion', 'Click nous ecrire'])
     })

--- a/assets/main.css
+++ b/assets/main.css
@@ -576,14 +576,6 @@ h2.phase-title em {
   }
 }
 
-
-/* TYPO PAGE APPROCHE */
-.decorated{
-  background-color: #E9E6FC;
-  width: max-content;
-  font-size: 1rem;
-}
-
 .bigger-font {
   font-weight: bold;
   font-size: 3.5em;


### PR DESCRIPTION
J'ai remis dans l'ordre la hierarchie des titres.
J'en ai profité pour retirer la classe `decorated` qui était un style uniquement utilisé sur la page Approche, ça simplifie le code et ça évite d'avoir des styles pas cohérents avec le DSFR et le reste du site.

**Avant**
<img width="391" alt="Capture d’écran 2022-06-22 à 12 31 50" src="https://user-images.githubusercontent.com/6756627/175008474-9e489238-b1d7-40ad-922e-b538f1b043e1.png">

**Après**
<img width="296" alt="Capture d’écran 2022-06-22 à 12 31 59" src="https://user-images.githubusercontent.com/6756627/175008460-bef45ea6-2986-4d12-bd8b-00715e4c34ac.png">


