### PR TITLE
Adapte l'affiliation à l'incubateur des startups en réalisation

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -29,9 +29,9 @@ layout: default
 
 {% capture incubator_info %}
 {% if phase.status == 'success' %}
-L'équipe a été portée par <a href="/startups/?incubateur={{ incubator_id | remove: '/incubators/' }}" title="{{ incubator.title }}">{{ incubator.title }}</a>
+  L'équipe a été portée par <a href="/startups/?incubateur={{ incubator_id | remove: '/incubators/' }}" title="{{ incubator.title }}">{{ incubator.title }}</a>
 {% else %}
-L'équipe est portée par <a href="/startups/?incubateur={{ incubator_id | remove: '/incubators/' }}" title="{{ incubator.title }}">{{ incubator.title }}</a>
+  L'équipe est portée par <a href="/startups/?incubateur={{ incubator_id | remove: '/incubators/' }}" title="{{ incubator.title }}">{{ incubator.title }}</a>
 {% endif %}
 {% endcapture %}
 

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -28,7 +28,11 @@ layout: default
 {% assign content = split_by_ul | join: '<ul class="fr-pl-4w"' %}
 
 {% capture incubator_info %}
+{% if phase.status == 'success' %}
+L'équipe a été portée par <a href="/startups/?incubateur={{ incubator_id | remove: '/incubators/' }}" title="{{ incubator.title }}">{{ incubator.title }}</a>
+{% else %}
 L'équipe est portée par <a href="/startups/?incubateur={{ incubator_id | remove: '/incubators/' }}" title="{{ incubator.title }}">{{ incubator.title }}</a>
+{% endif %}
 {% endcapture %}
 
 {% capture sponsor_info %}


### PR DESCRIPTION
Connected to #10367 

Pour un produit en phase de `Réalisation`, le message de portage par l'incubateur est mis au passé.

Avant : L'équipe est portée par _l'incubateur x_
Proposition de mise à jour : L'équipe a été portée par _l'incubateur x_

⚠️ code non testé en local (à vérifier en CI)

Contexte
---

Les produits en phase de réalisation (passation réussie) ne sont plus rattachés à l'incubateur (si ce n'est par le ❤️) mais une part des usagers retrouvent le service en passant par le site beta. Ces usagers ont alors une information de rattachement administratif erronée. 

Exemple de fiche produit actuelle pour [LexImpact](https://beta.gouv.fr/startups/leximpact.html) : 
![Capture d’écran 2022-06-23 à 19 02 07](https://user-images.githubusercontent.com/6567910/175356384-b2f4f3ee-f091-410f-94ef-9adfeae4dcdc.png)

De haut en bas sachant que le produit est désormais rattaché à l'administration de l'Assemblée nationale :
* L'adresse du site web en @ an.fr le laisse entendre.
* `Produit en réalisation` n'indique pas d'information supplémentaire pour un usager qui a inscrit "leximpact" sur son moteur de recherche et n'est peut-être pas familier avec beta.
* `L'équipe est portée par l'Incubateur...` met le doute sur la zone de rattachement.
* `L'équipe est sponsorisée par l'Assemblée...` ne semble pas répondre à toutes les interrogations de quelques usagers qui demandent à l'équipe : "vous êtes une startup/entreprise externe qui intervient pour l'Assemblée ?".


Cette PR est une solution minimale pour réduire la zone d'ambiguïté (sans tout résoudre 😅). On pourrait ajouter une ligne dédiée à l'institution ayant intégré le produit (sponsor dans l'exemple mais peut-être pas le cas de tous les sujets).
