### PR TITLE
 amélioration lisibilité : pages startup et job en col-md-8

### DIFF
--- a/_includes/job-content.html
+++ b/_includes/job-content.html
@@ -44,16 +44,16 @@
 
 <section class="fr-py-6w">
   {% if job.junior %}
-    <div class="fr-container fr-py-6w">
-      <div class="fr-highlight">
+    <div class="fr-container fr-py-6w fr-grid-row">
+      <div class="fr-highlight fr-col-md-8">
         Bienvenue aux juniors sur ce poste ! L'équipe assurera votre formation.
       </div>
     </div>
   {% endif %}
 
   {% if job.techno %}
-  <div class="fr-container fr-py-6w">
-    <div class="fr-highlight">
+  <div class="fr-container fr-py-6w fr-col-md-8 fr-grid-row">
+    <div class="fr-highlight fr-col-md-8">
       <p>Choix technologiques :</p>
       <ul class="fr-tags-group">
         {% for techno in job.techno %}
@@ -64,8 +64,10 @@
   </div>
   {% endif %}
 
-  <div class="fr-container">
-    {{ job.content }}
+  <div class="fr-container fr-grid-row">
+    <div class="fr-col-md-8">
+      {{ job.content }}
+    </div>
   </div>
 </section>
 

--- a/_includes/job-content.html
+++ b/_includes/job-content.html
@@ -44,16 +44,16 @@
 
 <section class="fr-py-6w">
   {% if job.junior %}
-    <div class="fr-container fr-py-6w fr-grid-row">
-      <div class="fr-highlight fr-col-md-8">
+    <div class="fr-container fr-py-6w">
+      <div class="fr-highlight">
         Bienvenue aux juniors sur ce poste ! L'équipe assurera votre formation.
       </div>
     </div>
   {% endif %}
 
   {% if job.techno %}
-  <div class="fr-container fr-py-6w fr-col-md-8 fr-grid-row">
-    <div class="fr-highlight fr-col-md-8">
+  <div class="fr-container fr-py-6w">
+    <div class="fr-highlight">
       <p>Choix technologiques :</p>
       <ul class="fr-tags-group">
         {% for techno in job.techno %}
@@ -64,10 +64,8 @@
   </div>
   {% endif %}
 
-  <div class="fr-container fr-grid-row">
-    <div class="fr-col-md-8">
-      {{ job.content }}
-    </div>
+  <div class="fr-container">
+    {{ job.content }}
   </div>
 </section>
 

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -109,23 +109,25 @@ Le suivi des bonnes pratiques de ce produit
 {% endcapture %}
 
 <div class="notification full-width section-grey">
-  <div class="fr-container">
-    <ul>
-      <li>{{ incubator_info }}</li>
-      <li>{{ sponsor_info }}</li>
-      <li>{{ contact_info }}</li>
-    {% unless phase.status == 'investigation' %}
-      <li>{{ statistiques_info }}</li>
-      <li>{{ source_info }}</li>
-      <li>{{ budget_info }}</li>
-      {{ accessibilite }}
-      {{ analyse_risques }}
-      <li>{{ dashlord }}</li>
-      {% if page.techno %}
-      <li>{{ techno_info }}</li>
-      {% endif %}
-    {% endunless %}
-    </ul>
+  <div class="fr-container fr-grid-row">
+    <div class="fr-col-md-8">
+      <ul>
+        <li>{{ incubator_info }}</li>
+        <li>{{ sponsor_info }}</li>
+        <li>{{ contact_info }}</li>
+      {% unless phase.status == 'investigation' %}
+        <li>{{ statistiques_info }}</li>
+        <li>{{ source_info }}</li>
+        <li>{{ budget_info }}</li>
+        {{ accessibilite }}
+        {{ analyse_risques }}
+        <li>{{ dashlord }}</li>
+        {% if page.techno %}
+        <li>{{ techno_info }}</li>
+        {% endif %}
+      {% endunless %}
+      </ul>
+    </div>
   </div>
 </div>
 
@@ -140,8 +142,10 @@ Le suivi des bonnes pratiques de ce produit
     </div>
   {% endif %}
 
-  <div class="fr-container fr-py-2w">
-    {{ content }}
+  <div class="fr-container fr-py-2w fr-grid-row">
+    <div class="fr-col-md-8">
+      {{ content }}
+    </div>
   </div>
 </section>
 

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -109,7 +109,7 @@ Le suivi des bonnes pratiques de ce produit
 {% endcapture %}
 
 <div class="notification full-width section-grey">
-  <div class="fr-container fr-grid-row">
+  <div class="fr-container fr-grid-row fr-grid-row--center">
     <div class="fr-col-md-8">
       <ul>
         <li>{{ incubator_info }}</li>
@@ -142,7 +142,7 @@ Le suivi des bonnes pratiques de ce produit
     </div>
   {% endif %}
 
-  <div class="fr-container fr-py-2w fr-grid-row">
+  <div class="fr-container fr-py-2w fr-grid-row fr-grid-row--center">
     <div class="fr-col-md-8">
       {{ content }}
     </div>


### PR DESCRIPTION
Sur desktop les pages job et startups sont difficilement lisibles car le contenu s'étale sur toute la page, ce qui fait des lignes très longues.
Je propose ici de réduire à 8 colonnes maximum.

les recommendations de lisibilité du DSFR :

    Il est recommandé de veiller à limiter le nombre de caractère par ligne. Nous vous recommandons d’utiliser un conteneur de maximum 8 colonnes pour les contenus.
    Pour les tailles de typographies S et XS, il est recommandé d’utiliser un conteneur moins large : en effet des études montrent qu’entre 45 et 75 caractères la lecture est satisfaisante pour le desktop, 35 à 40 caractères pour le mobile.

(cette PR annule et remplace #10487 dont la preview a expiré)
![both](https://user-images.githubusercontent.com/883348/176113712-ee7e15d6-c462-4b3c-93d2-1b3426a1efd3.png)

