### PR TITLE
remove redundant title text in header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,7 +33,7 @@
                 {% if item.external == true %}
                   <a class="fr-link" href="{{ item.url }}" title="{{ item.label }} - nouvelle fenêtre" target="_blank" rel="noopener">{{ item.label }}</a>
                 {% else %}
-                  <a class="fr-link" href="{{ item.url }}" title="{{ item.label }}">{{ item.label }}</a>
+                  <a class="fr-link" href="{{ item.url }}">{{ item.label }}</a>
                 {% endif %}
               </li>
               {% endfor %}


### PR DESCRIPTION
Suppression du titre du lien qui est redondant avec le contenu du lien.