### PR TITLE
fix error html in menu according to DSFR

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,7 @@
             </div>
 
             <div class="fr-header__navbar">
-              <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-833" aria-haspopup="menu" title="Menu">
+              <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-833" aria-haspopup="menu" title="Menu" id="fr-btn-menu-mobile">
                   Menu
               </button>
             </div>
@@ -45,7 +45,7 @@
   </div>
 
   <!-- Navigation principale -->
-  <div class="fr-header__menu fr-modal" id="modal-833" aria-labelledby="button-834">
+  <div class="fr-header__menu fr-modal" id="modal-833" aria-labelledby="fr-btn-menu-mobile">
     <div class="fr-container">
       <button class="fr-link--close fr-link" aria-controls="modal-833">Fermer</button>
       <div class="fr-header__menu-links"></div>


### PR DESCRIPTION
Cette PR répond à la carte le code html est valide.
J'ai fait la correction en m'appuyant sur le header dans la doc du DSFR.
Pour verifier que c'est ok :
- verifier que le menu fonctionne tjs 😅 
- faire passer le code dans [le validateur](https://validator.w3.org/nu/#textarea) 