### PR TITLE
clean css file with recent MAJ from DSFR

### DIFF
--- a/_includes/job-content.html
+++ b/_includes/job-content.html
@@ -6,23 +6,23 @@
 {% include hero-job.html startup=startup roles=job.roles friend=job.friend %}
 
 {% if job.type == 'friend' %}
-  <div class="notification full-width">
-    <div class="fr-container">
-      Une offre à pourvoir chez nos camarades <br /><a href="{{ job.externalURL}}">Voir l'offre sur le site de {{ job.friend }}</a>
+  <div class="fr-container">
+    <div class="fr-alert fr-alert--info fr-alert--sm fr-mb-1w">
+      <p>Une offre à pourvoir chez nos camarades <br /><a href="{{ job.externalURL}}">Voir l'offre sur le site de {{ job.friend }}</a></p>
     </div>
   </div>
 {% endif %}
 
 {% if job.open %}
-  <div class="notification full-width">
-    <div class="fr-container">
-      Poste ouvert le <time datetime="{{ job.date | date:'%Y-%m-%d' }}">{{ job.date | date: "%d/%m/%Y" }}</time>
+  <div class="fr-container">
+    <div class="fr-alert fr-alert--info fr-alert--sm">
+      <p>Poste ouvert le <time datetime="{{ job.date | date:'%Y-%m-%d' }}">{{ job.date | date: "%d/%m/%Y" }}</time></p>
     </div>
   </div>
 {% else %}
-  <div class="notification warning full-width">
-    <div class="fr-container">
-      Ce poste a été pourvu depuis son ouverture le <time datetime="{{ job.date | date:'%Y-%m-%d' }}">{{ job.date | date: "%d/%m/%Y" }}</time>
+  <div class="fr-container">
+    <div class="fr-alert fr-alert--error fr-alert--sm">
+      <p>Ce poste a été pourvu depuis son ouverture le <time datetime="{{ job.date | date:'%Y-%m-%d' }}">{{ job.date | date: "%d/%m/%Y" }}</time></p>
     </div>
   </div>
 {% endif %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -108,7 +108,7 @@ Le suivi des bonnes pratiques de ce produit
 {% endif %}
 {% endcapture %}
 
-<div class="notification full-width section-grey">
+<div class="fr-py-6w section-grey">
   <div class="fr-container">
     <ul>
       <li>{{ incubator_info }}</li>

--- a/assets/main.css
+++ b/assets/main.css
@@ -1,35 +1,3 @@
-/* Le Système de design n'a pas encore de notifications */
-
-.notification {
-  background: #b4e1fa;
-  border: 1px solid #006be6;
-  border-radius: 3px;
-  padding: 1em;
-  margin-bottom: 1em;
-  position: relative;
-}
-
-.notification.full-width {
-  width: 100%;
-  margin-bottom: 0;
-  border: 0;
-}
-
-.notification.success {
-  background: #daf5e7;
-  border-color: #03bd5b;
-}
-
-.notification.warning {
-  background: #fff0e4;
-  border-color: #ff9947;
-}
-
-.notification.error {
-  background: #efaca6;
-  border-color: #d63626;
-}
-
 /* En attendant de revoir tous les titres de pages */
 
 .hero {

--- a/assets/main.css
+++ b/assets/main.css
@@ -1,10 +1,3 @@
-/* À supprimer quand le Système de design sera mis à jour */
-hr {
-  height: 1px;
-  border: 0;
-  background: var(--g300);
-}
-
 /* Le Système de design n'a pas encore de notifications */
 
 .notification {

--- a/assets/main.css
+++ b/assets/main.css
@@ -68,44 +68,6 @@
   color: #4941C0;
 }
 
-/* Cette classe n'est plus utilisée que sur la home.html, supprimer lors de la refonte prochaine */
-
-.row {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.row > * {
-  max-width: 50em;
-}
-
-.row > * {
-  margin: 0 2em;
-}
-
-@media (max-width: 749px) {
-  .row {
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-    -ms-flex-direction: column;
-    flex-direction: column;
-  }
-
-  .row > * {
-    margin: 1em;
-  }
-}
 
 /* Couleurs de sections et espacemements */
 .section-grey {


### PR DESCRIPTION
J'ai fait un peu le ménage dans les classes les plus évidentes à retirer avec la MAJ récente du DSFR.

Il y a un changement visuel au niveau des notifications pour se mettre en accord avec le DSFR - mais qui ne va pas rester comme cet été les offres d'emploi seront migrées sur Welcome To the Jungle.

**Après**
<img width="1312" alt="Capture d’écran 2022-07-01 à 17 42 37" src="https://user-images.githubusercontent.com/6756627/176929495-0140fb05-3197-48a3-8e85-55ce5da3b5f4.png">

**Avant**

<img width="1291" alt="Capture d’écran 2022-07-01 à 17 42 23" src="https://user-images.githubusercontent.com/6756627/176929479-e4c9fb1c-ec6a-4d75-a96f-04a9568a7969.png">

