### PR TITLE
supprime certaines descriptions des alt sur les img && ajoute des titres pour mieux structurer page

### DIFF
--- a/_layouts/brigade.html
+++ b/_layouts/brigade.html
@@ -70,10 +70,10 @@ site.lang | default: "fr" -%}
           <div class="fr-card fr-card--no-arrow fr-card--grey">
             <div class="fr-card__body">
               <div class="fr-card__content">
-                <p class="bigger-font text-purple">01</p>
-                <h3 class="fr-card__title">
+                <h3 class="bigger-font text-purple">01</h3>
+                <h4 class="fr-card__title">
                   Gestion de crise et situation d’urgence
-                </h3>
+                </h4>
                 <p class="fr-card__desc">Proposer et mettre en oeuvre rapidement une solution pour répondre à des situations de crise ou d’urgence
                 </p>
               </div>
@@ -84,10 +84,10 @@ site.lang | default: "fr" -%}
           <div class="fr-card fr-card--no-arrow fr-card--grey">
             <div class="fr-card__body">
               <div class="fr-card__content">
-                <p class="bigger-font text-purple">02</p>
-                <h3 class="fr-card__title">
+                <h3 class="bigger-font text-purple">02</h3>
+                <h4 class="fr-card__title">
                   Politique prioritaire du quinquennat
-                </h3>
+                </h4>
                 <p class="fr-card__desc">Renforcer l’impact d’une politique prioritaire à travers le
                   développement de services publics numériques
                 </p>
@@ -99,10 +99,10 @@ site.lang | default: "fr" -%}
           <div class="fr-card fr-card--grey fr-card--no-arrow">
             <div class="fr-card__body">
               <div class="fr-card__content">
-                <p class="bigger-font text-purple ">03</p>
-                <h3 class="fr-card__title">
+                <h3 class="bigger-font text-purple ">03</h3>
+                <h4 class="fr-card__title">
                   Communs numériques interministériels
-                </h3>
+                </h4>
                 <p class="fr-card__desc">Renforcer et soutenir l’action du réseau d’incubateurs
                   beta.gouv et des Startups d’États par la création de
                   communs
@@ -135,7 +135,7 @@ site.lang | default: "fr" -%}
         <h2 class="fr-pb-6w">L'approche Brigade</h2>
         <div class="fr-grid-row fr-grid-row--gutters">
           <div class="fr-col-md-2 fr-col-4">
-            <img src="/assets/images/icon_brigade.svg" alt="Illustration Brigade" />
+            <img src="/assets/images/icon_brigade.svg" alt="" />
           </div>
           <div class="fr-col-md-10 fr-col-12">
               <h3 class="fr-h6 fr-mb-0">Une logique d’impact confrontée au terrain </h3>
@@ -147,7 +147,7 @@ site.lang | default: "fr" -%}
         </div>
         <div class="fr-grid-row fr-grid-row--gutters">
           <div class="fr-col-md-2 fr-col-4">
-            <img src="/assets/images/icon_politician.svg" alt="Illustration politique" />
+            <img src="/assets/images/icon_politician.svg" alt="" />
           </div>
           <div class="fr-col-md-10 fr-col-12">
               <h3 class="fr-h6 fr-mb-0">Un pilotage interministériel au profit d’une perspective usager cohérente </h3>
@@ -159,7 +159,7 @@ site.lang | default: "fr" -%}
         </div>
         <div class="fr-grid-row fr-grid-row--gutters">
           <div class="fr-col-md-2 fr-col-4">
-            <img src="/assets/images/icon_pressure.svg" alt="Illustration pression" />
+            <img src="/assets/images/icon_pressure.svg" alt="" />
           </div>
           <div class="fr-col-md-10 fr-col-12">
               <h3 class="fr-h6 fr-mb-0">Une méthodologie d’accompagnement adaptée et rythmée par jalons </h3>
@@ -234,7 +234,7 @@ site.lang | default: "fr" -%}
         <h2 class="fr-pb-6w">Les étapes de l'intervention de la Brigade de beta.gouv</h2>
         <div class="fr-grid-row fr-grid-row--gutters fr-mb-6w">
           <div class="fr-col-md-4 fr-col-12">
-            <img src="/assets/images/step_1_brigade.svg" alt="Illustration des étapes de la Brigade" />
+            <img src="/assets/images/step_1_brigade.svg" alt="" />
           </div>
           <div class="fr-col-md-8 fr-col-12">
             <h3 class="fr-text--md fr-mb-0">Cadrage</h3>
@@ -253,7 +253,7 @@ site.lang | default: "fr" -%}
 
         <div class="fr-grid-row fr-grid-row--gutters fr-mb-6w">
           <div class="fr-col-md-4 fr-col-12">
-            <img src="/assets/images/step_2_brigade.svg" alt="Illustration des étapes de la Brigade" />
+            <img src="/assets/images/step_2_brigade.svg" alt="" />
           </div>
           <div class="fr-col-md-8 fr-col-12">
             <h3 class="fr-text--md fr-mb-0">Investigation</h3>
@@ -272,7 +272,7 @@ site.lang | default: "fr" -%}
         </div>
         <div class="fr-grid-row fr-grid-row--gutters fr-mb-6w">
           <div class="fr-col-md-4 fr-col-12">
-            <img src="/assets/images/step_3_brigade.svg" alt="Illustration des étapes de la Brigade" />
+            <img src="/assets/images/step_3_brigade.svg" alt="" />
           </div>
           <div class="fr-col-md-8 fr-col-12">
             <h3 class="fr-text--md fr-mb-0">Construction</h3>
@@ -291,7 +291,7 @@ site.lang | default: "fr" -%}
         </div>
         <div class="fr-grid-row fr-grid-row--gutters">
           <div class="fr-col-md-4 fr-col-12">
-            <img src="/assets/images/step_4_brigade.svg" alt="Illustration des étapes de la Brigade" />
+            <img src="/assets/images/step_4_brigade.svg" alt="" />
           </div>
           <div class="fr-col-md-8 fr-col-12">
             <h3 class="fr-text--md fr-mb-0">Transfert</h3>
@@ -319,7 +319,7 @@ site.lang | default: "fr" -%}
     <div class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col fr-col-12 fr-col-md-6">
         <img src="/assets/images/seminaire.jpg"
-             alt="La communauté au séminaire de septembre 2021" />
+             alt="La communauté beta.gouv.fr au séminaire de septembre 2021" />
       </div>
       <div class="fr-col fr-col-12 fr-col-md-6">
         <p class="fr-text--lg fr-mb-5v">beta.gouv, c'est une communauté définie par :</p>

--- a/_layouts/brigade.html
+++ b/_layouts/brigade.html
@@ -117,7 +117,7 @@ site.lang | default: "fr" -%}
 </section>
 <section class="fr-py-6w">
   <div class="fr-container">
-    <h2>Découvrez les services numériques soutenus par la Brigade</h2>
+    <h2 class="section-title">Découvrez les services numériques soutenus par la Brigade</h2>
     <div class="fr-col-12 fr-pt-6w">
       <div class="fr-grid-row fr-grid-row--gutters">
         {%- for startup in startups_brigade -%}

--- a/_layouts/brigade.html
+++ b/_layouts/brigade.html
@@ -117,7 +117,7 @@ site.lang | default: "fr" -%}
 </section>
 <section class="fr-py-6w">
   <div class="fr-container">
-    <h2 class="section-title">Découvrez les services numériques soutenus par la Brigade</h2>
+    <h2>Découvrez les services numériques soutenus par la Brigade</h2>
     <div class="fr-col-12 fr-pt-6w">
       <div class="fr-grid-row fr-grid-row--gutters">
         {%- for startup in startups_brigade -%}

--- a/assets/main.css
+++ b/assets/main.css
@@ -304,11 +304,6 @@ h2.phase-title em {
   font-weight: bold;
 }
 
-.phase-description {
-  font-style: italic;
-  color: $darker-grey;
-}
-
 main .fr-container img {
   width: 100%;
 }

--- a/assets/main.css
+++ b/assets/main.css
@@ -304,6 +304,11 @@ h2.phase-title em {
   font-weight: bold;
 }
 
+.phase-description {
+  font-style: italic;
+  color: $darker-grey;
+}
+
 main .fr-container img {
   width: 100%;
 }


### PR DESCRIPTION
J'ai supprimé la plupart des descriptions alt des icon car ce n'est pas une bonne pratique de mettre "illustration" dans les alt puisque une img vient presque forcément illustrer quelque chose. Quand une img est décorative un alt vide est valide. 

J'ai laissé la description de la photo.

J'ai remis en ordre trois titres pour ce que soit mieux structuré (je l'avais pas fait dans mon ancienne PR !)