### PR TITLE
Ajoute poids et format du fichier en téléchargement

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -27,7 +27,7 @@ links:
       label: Nous contacter
       target: _pages/contact.md
     -
-      label: Présentation de référence
+      label: Télécharger la présentation de référence (PDF - 1,8 Mo)
       url: https://beta.gouv.fr/content/docs/betagouv_presentation.pdf
 -
     label:


### PR DESCRIPTION
J'ai ajouté la mention "télécharger" afin que l'action soit claire pour les utilisateur·ice·s ainsi que le format et le poids du fichier. 

@IshanB doit se charger de rendre le PDF accessible dans les semaines à venir. 