### PR TITLE
npm: remove remixicons dependency

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,8 +54,6 @@ exclude: [
 ]
 
 copy_to_dest:
-  - source: node_modules/remixicon/fonts/.
-    target: assets/remixicon/fonts/
   - source: node_modules/@gouvfr/dsfr/dist/.
     target: assets/gouvfr/
 

--- a/_includes/card-incubator.html
+++ b/_includes/card-incubator.html
@@ -19,7 +19,7 @@
           <div class="markdown">{{ incubator.excerpt }}</div>
           {% if incubator.address %}<p class=fr-mb-3w>
             <span>
-              <i class="ri-map-pin-fill"></i>
+              <i class="fr-icon-map-pin-2-line"></i>
           </span>{{ incubator.address }}</p>
           {% endif %}
           <div class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
     {% if page.robots %}
       <meta name="robots" content="{{page.robots}}" />
     {% endif %}
-    
+
     {% assign description = page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape %}
     <meta name="description" content="{{ description }}">
     <meta property="og:description" content="{{ description }}">
@@ -51,8 +51,6 @@
     <link rel="stylesheet" type="text/css" href="/assets/main.css">
     <link rel="stylesheet" type="text/css" href="/assets/gouvfr/dsfr.min.css">
     <link rel="stylesheet" type="text/css" href="/assets/gouvfr/utility/utility.min.css">
-    <link rel="stylesheet" type="text/css" href="/assets/remixicon/fonts/remixicon.css">
-
     {% for file in page.additional_css %}
       <link rel="stylesheet" type="text/css" href="{% if file contains '://' %}{{ file }}{% else %}/assets/additional/style/{{ file }}{% endif %}">
     {% endfor %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
-                "@gouvfr/dsfr": "1.6",
-                "remixicon": "^2.5.0"
+                "@gouvfr/dsfr": "1.6"
             }
         },
         "node_modules/@gouvfr/dsfr": {
@@ -16,11 +15,6 @@
             "engines": {
                 "node": ">=14.18.0"
             }
-        },
-        "node_modules/remixicon": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/remixicon/-/remixicon-2.5.0.tgz",
-            "integrity": "sha512-q54ra2QutYDZpuSnFjmeagmEiN9IMo56/zz5dDNitzKD23oFRw77cWo4TsrAdmdkPiEn8mxlrTqxnkujDbEGww=="
         }
     },
     "dependencies": {
@@ -28,11 +22,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.6.0.tgz",
             "integrity": "sha512-1d/Uh9xqMWYGYG+/Zb5eg2lROB8MFq0Dy2G000/L8qAWi/LjQaX27U3TfCGwQ5l34Pna6x2/HV74foeIfsoaGA=="
-        },
-        "remixicon": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/remixicon/-/remixicon-2.5.0.tgz",
-            "integrity": "sha512-q54ra2QutYDZpuSnFjmeagmEiN9IMo56/zz5dDNitzKD23oFRw77cWo4TsrAdmdkPiEn8mxlrTqxnkujDbEGww=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
     "dependencies": {
-        "@gouvfr/dsfr": "1.6",
-        "remixicon": "^2.5.0"
+        "@gouvfr/dsfr": "1.6"
     }
 }


### PR DESCRIPTION
The icons now live directly in the DSFR. There is no need to drag
remixicons as well.