### PR TITLE
Title hierarchy page investigation a11y

### DIFF
--- a/_includes/hero-page.html
+++ b/_includes/hero-page.html
@@ -1,6 +1,6 @@
 {% if page.title %}
 <div class="fr-container fr-my-6w">
-  <span>{{ include.subtitle | escape }}</span>
-  <h1>{{ include.title | escape }}</h1>
+  <h1 class="fr-text--md fr-mb-0">{{ include.subtitle | escape }}</h1>
+  <h2>{{ include.title | escape }}</h2>
 </div>
 {% endif %}

--- a/_pages/programme/investigation.md
+++ b/_pages/programme/investigation.md
@@ -15,12 +15,12 @@ breadcrumbs:
 <section>
   <div class="fr-grid-row fr-grid-row--gutters fr-py-6w">
         <div class="fr-col fr-col-12 fr-col-md-4">
-            <div class="fr-sidemenu beta-sidemenu-sticky" aria-label="Menu latéral">
+            <nav class="fr-sidemenu fr-sidemenu--sticky" aria-label="Menu latéral">
                 <div class="fr-sidemenu__inner">
                     <button class="fr-sidemenu__btn" hidden aria-controls="fr-sidemenu-wrapper" aria-expanded="false">Dans cette rubrique</button>
                     <img src="/img/programme/investigation.png" alt="" class="hidden-mobile" />
                     <div class="fr-collapse" id="fr-sidemenu-wrapper">
-                        <h1 class="fr-sidemenu__title fr-pl-1w">Sommaire</h1>
+                        <div class="fr-sidemenu__title fr-pl-1w" >Sommaire</div>
                         <ul class="fr-sidemenu__list">
                           <li class="fr-sidemenu__item">
                                 <a class="fr-sidemenu__link" href="#pourquoi" target="_self"> 1. Pourquoi réaliser cette étape&nbsp;? </a>
@@ -43,67 +43,46 @@ breadcrumbs:
                         </ul>
                     </div>
                 </div>
-            </div>
+            </nav>
         </div>
         <div class="fr-col fr-col-12 fr-col-md-8">
-            <!-- <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12" id="investigation">
-                    <h2>L'investigation</h2>
-                    <p>Tous les partenariats avec beta.gouv.fr débutent par une **phase d'investigation** qui permet de mieux cerner le problème auquel on souhaite s'attaquer, de s'assurer que des solutions qui y répondent n'existent pas déjà et de confirmer qu'il est pertinent d'investir dans un service numérique pour le résoudre.</p>
-                    <p>Pendant environ 9 semaines et avec l’accompagnement d’un mentor expérimenté, beta.gouv.fr collabore avec votre administration afin d’investiguer un problème et vérifier qu’il est assez universel et criant pour justifier un investissement dans un service numérique. Au terme de cette phase, appelée “<b>investigation</b>”, les apprentissages de l'équipe en charge de l'investigation sont présentés durant un <b>comité de lancement</b> pour que les décideuses et décideurs publics aient tous les éléments en main afin de savoir s’il convient ou non de poursuivre les travaux et de passer en [phase de construction](https://beta.gouv.fr/approche/construction). Toutes les investigations n'aboutissent pas sur le lancement de la construction d'un service numérique avec beta.gouv.fr.</p>
-                </div>
-            </div> -->
-            <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12" id="pourquoi">
-                    <h2>Quel est l’enjeu de l’investigation ?</h2>
-                    <p>Pour nous, la technologie est un moyen et non une fin : le numérique ne parviendra certainement pas à résoudre tous les problèmes. Nous le répétons souvent : ce n’est pas parce que c’est innovant que c’est forcément mieux. C’est pourquoi nous recommandons toujours de (re)partir du problème rencontré par les utilisateurs (et non d’une solution pressentie) à travers une écoute attentive. Cette approche présente l’avantage de minimiser grandement le risque d’investir dans un produit qui ne répond pas aux vrais besoins des utilisateurs et qui répondra donc moins bien aux objectifs fixés. Elle permet en particulier, preuves à l’appui, de s’assurer de construire un service numérique qui soit vraiment utile, c’est-à-dire qui réponde véritablement aux besoins des gens et/ou qui ait le maximum d’impact.</p>
-                </div>
+            <div id="pourquoi">
+              <h3>Quel est l’enjeu de l’investigation ?</h3>
+              <p>Pour nous, la technologie est un moyen et non une fin : le numérique ne parviendra certainement pas à résoudre tous les problèmes. Nous le répétons souvent : ce n’est pas parce que c’est innovant que c’est forcément mieux. C’est pourquoi nous recommandons toujours de (re)partir du problème rencontré par les utilisateurs (et non d’une solution pressentie) à travers une écoute attentive. Cette approche présente l’avantage de minimiser grandement le risque d’investir dans un produit qui ne répond pas aux vrais besoins des utilisateurs et qui répondra donc moins bien aux objectifs fixés. Elle permet en particulier, preuves à l’appui, de s’assurer de construire un service numérique qui soit vraiment utile, c’est-à-dire qui réponde véritablement aux besoins des gens et/ou qui ait le maximum d’impact.</p>
             </div>
-            <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12" id="qui">
-                    <h2>Qui sera impliqué ?</h2>
-                    <p>Dans cette première étape qui prend en général 9 semaines, l’intrapreneur(e) accompagné d’un ou une coach va au contact des utilisateurs pour bien cerner le problème qu’il ou elle souhaite résoudre par un service public numérique.</p>
-                </div>
+            <div id="qui">
+                <h3>Qui sera impliqué ?</h3>
+                <p>Dans cette première étape qui prend en général 9 semaines, l’intrapreneur(e) accompagné d’un ou une coach va au contact des utilisateurs pour bien cerner le problème qu’il ou elle souhaite résoudre par un service public numérique.</p>
             </div>
-            <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12" id="resultat">
-                    <h2>Qu’est-ce qui sera produit pendant cette étape ?</h2>
-                    <p>A la fin de l’investigation, l’intra présentera au comité d’investissement le résultat de ses recherches utilisateur : il ou elle aura déjà imaginé des pistes de solutions et aura testé la valeur d’une ou plusieurs solutions auprès des utilisateurs, par le biais d’un prototype, d’une maquette ou d’un site minimal.</p>
-                </div>
+            <div id="resultat">
+              <h3>Qu’est-ce qui sera produit pendant cette étape ?</h3>
+              <p>A la fin de l’investigation, l’intra présentera au comité d’investissement le résultat de ses recherches utilisateur : il ou elle aura déjà imaginé des pistes de solutions et aura testé la valeur d’une ou plusieurs solutions auprès des utilisateurs, par le biais d’un prototype, d’une maquette ou d’un site minimal.</p>
             </div>
-            <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12" id="condition">
-                    <h2>Quelles sont les conditions à réunir ?</h2>
-                    <p>
-                      ✅ définir un problème à investiguer (sans présupposer la solution numérique) ;<br />
-                      ✅ libérer un agent public “intrapreneur” au moins deux jours par semaine de ses tâches habituelles.<br />
-                      ✅ autoriser le télétravail de cette personne ;<br />
-                      ✅ lui donner un accès à un ordinateur portable et un Internet « libre », pour qu’elle accède aux outils utilisés par la communauté beta.gouv (Mattermost, Trello, GitHub…) ;<br />
-                      ✅ l’autoriser à ouvrir toutes les portes utiles à sa mission, sans validation préalable, afin d’échanger avec les personnes jugées les plus pertinentes (au sein de son administration ou ailleurs)<br />
-                      ✅ obtenir le soutien d’un “sponsor” de haut niveau (exemples : directeur ou directrice d’administration centrale ; directeur ou directrice général(e) des services) qui adhère à la démarche beta.gouv, qui garantit l’autonomie et la liberté de l’équipe et qui s’engage à participer au comité de lancement final. Concrètement l’intrapreneur accompagné par beta.gouv rapporte directement au sponsor plutôt qu’à sa hiérarchie habituelle.
-                    </p>
-                </div>
+            <div id="condition">
+              <h3>Quelles sont les conditions à réunir ?</h3>
+              <p>
+                ✅ définir un problème à investiguer (sans présupposer la solution numérique) ;<br />
+                ✅ libérer un agent public “intrapreneur” au moins deux jours par semaine de ses tâches habituelles.<br />
+                ✅ autoriser le télétravail de cette personne ;<br />
+                ✅ lui donner un accès à un ordinateur portable et un Internet « libre », pour qu’elle accède aux outils utilisés par la communauté beta.gouv (Mattermost, Trello, GitHub…) ;<br />
+                ✅ l’autoriser à ouvrir toutes les portes utiles à sa mission, sans validation préalable, afin d’échanger avec les personnes jugées les plus pertinentes (au sein de son administration ou ailleurs)<br />
+                ✅ obtenir le soutien d’un “sponsor” de haut niveau (exemples : directeur ou directrice d’administration centrale ; directeur ou directrice général(e) des services) qui adhère à la démarche beta.gouv, qui garantit l’autonomie et la liberté de l’équipe et qui s’engage à participer au comité de lancement final. Concrètement l’intrapreneur accompagné par beta.gouv rapporte directement au sponsor plutôt qu’à sa hiérarchie habituelle.
+              </p>
             </div>
-            <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12" id="financer">
-                    <h2>Comment financer cette étape ?</h2>
-                    <p>La phase d’investigation peut être financée par la Direction interministérielle du numérique (DINUM) si elle répond aux conditions définies ci-dessus. Dans ce cas-là, la DINUM recrute le ou la coach, participe à la sélection de l'agent public intrapreneur et est conviée au comité d'investissement afin d'établir si un produit peut être lancé selon l'approche Startup d'Etat. Le cas échéant, le produit intègrera le programme beta.gouv et devra se conformer aux standards définis par la DINUM.</p>
-                    <p>Le lancement de la phase d'investigation est conditionné à la transmission par le sponsor d'une fiche d'engagement complétée.<br />
-                    <a href="https://beta.gouv.fr/content/docs/engagement.docx">Télécharger la fiche d'engagement (DOCX - 520 Ko)</a></p>
-                </div>
+            <div id="financer">
+              <h3>Comment financer cette étape ?</h3>
+              <p>La phase d’investigation peut être financée par la Direction interministérielle du numérique (DINUM) si elle répond aux conditions définies ci-dessus. Dans ce cas-là, la DINUM recrute le ou la coach, participe à la sélection de l'agent public intrapreneur et est conviée au comité d'investissement afin d'établir si un produit peut être lancé selon l'approche Startup d'Etat. Le cas échéant, le produit intègrera le programme beta.gouv et devra se conformer aux standards définis par la DINUM.</p>
+              <p>Le lancement de la phase d'investigation est conditionné à la transmission par le sponsor d'une fiche d'engagement complétée.<br />
+              <a href="https://beta.gouv.fr/content/docs/engagement.docx">Télécharger la fiche d'engagement (DOCX - 520 Ko)</a></p>
             </div>
-            <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12" id="ensuite">
-                    <h2>Et ensuite ?</h2>
-                    <p>A la fin de l’investigation, le comité d’investissement se réunit et décide de l’abandon ou de la poursuite de produit. En cas de poursuite, on rentre dans la réalisation du service public numérique !<br />
-                    <a href="https://beta.gouv.fr/approche/construction">Découvrir la phase de réalisation d'un service public numérique</a></p>
-                </div>
+            <div id="ensuite">
+              <h3>Et ensuite ?</h3>
+              <p>A la fin de l’investigation, le comité d’investissement se réunit et décide de l’abandon ou de la poursuite de produit. En cas de poursuite, on rentre dans la réalisation du service public numérique !<br />
+              <a href="https://beta.gouv.fr/approche/construction">Découvrir la phase de réalisation d'un service public numérique</a></p>
             </div>
-            <div class="fr-grid-row fr-grid-row--gutters fr-p-1w section-grey">
-                <div class="fr-col-12 text-center" id="contact">
-                    <h4>Vous souhaitez lancer une investigation avec nous ? Parlez-nous de votre projet !</h4>
-                    <a id="btn-nous-ecrire" class="fr-btn fr-btn--md" href="https://startupdetat.typeform.com/to/jX2Ko0pF#source=sitebeta">Nous écrire</a>
-                </div>
+            <div class="fr-callout fr-fi-information-line">
+              <h2 class="fr-callout__title">Vous souhaitez lancer une investigation avec nous ? Parlez-nous de votre projet !</h2>
+              <a id="btn-nous-ecrire" class="fr-btn fr-btn--md" href="https://startupdetat.typeform.com/to/jX2Ko0pF#source=sitebeta">Nous écrire</a>
             </div>
         </div>
     </div>

--- a/_pages/programme/investigation.md
+++ b/_pages/programme/investigation.md
@@ -82,7 +82,7 @@ breadcrumbs:
             </div>
             <div class="fr-callout fr-fi-information-line">
               <h2 class="fr-callout__title">Vous souhaitez lancer une investigation avec nous ? Parlez-nous de votre projet !</h2>
-              <a id="btn-nous-ecrire" class="fr-btn fr-btn--md" href="https://startupdetat.typeform.com/to/jX2Ko0pF#source=sitebeta">Nous écrire</a>
+              <a id="btn-nous-ecrire" class="fr-btn fr-btn--md" target="_blank" title="Nous écrire - nouvelle fenêtre" href="https://startupdetat.typeform.com/to/jX2Ko0pF#source=sitebeta">Nous écrire</a>
             </div>
         </div>
     </div>

--- a/_pages/programme/investigation.md
+++ b/_pages/programme/investigation.md
@@ -20,7 +20,7 @@ breadcrumbs:
                     <button class="fr-sidemenu__btn" hidden aria-controls="fr-sidemenu-wrapper" aria-expanded="false">Dans cette rubrique</button>
                     <img src="/img/programme/investigation.png" alt="" class="hidden-mobile" />
                     <div class="fr-collapse" id="fr-sidemenu-wrapper">
-                        <div class="fr-sidemenu__title fr-pl-1w" >Sommaire</div>
+                        <div class="fr-sidemenu__title fr-pl-1w">Sommaire</div>
                         <ul class="fr-sidemenu__list">
                           <li class="fr-sidemenu__item">
                                 <a class="fr-sidemenu__link" href="#pourquoi" target="_self"> 1. Pourquoi réaliser cette étape&nbsp;? </a>


### PR DESCRIPTION
J'ai réorganisé la hiérarchie des titres.
J'en ai profité pour 
- retirer des divs de grilles inutiles
- supprimer un gros bloc de texte commenté depuis un moment
- utiliser la bonne classe du DSFR pour que le menu soit réellement sticky
- utiliser la class "callout" du DSFR pour le bloc de fin "nous ecrire"
- ajouter un target blank sur le lien "nous ecrire" car il s'agit d'un typeform (je l'avais raté dans la PR sur les liens 😶 )