### PR TITLE
déplace 'nouvelle fenêtre' dans le title

### DIFF
--- a/_layouts/brigade.html
+++ b/_layouts/brigade.html
@@ -26,7 +26,7 @@ site.lang | default: "fr" -%}
           </span>
           La Brigade vous accompagne dans la création de services publics numériques prioritaires
         </p>
-        <a class="fr-btn fr-btn--md fr-enlarge-link fr-btn--secondary button-white fr-mt-2w" href="mailto:brigade@beta.gouv.fr">Contacter la Brigade - nouvelle fenêtre</a>
+        <a class="fr-btn fr-btn--md fr-enlarge-link fr-btn--secondary button-white fr-mt-2w" href="mailto:brigade@beta.gouv.fr" title="Contacter la Brigade - nouvelle fenêtre">Contacter la Brigade</a>
       </div>
       <div class="fr-col fr-col-12 fr-col-md-5 hidden-mobile">
         <div class="home-hero-anim">
@@ -247,7 +247,7 @@ site.lang | default: "fr" -%}
             </div>
             <p class="fr-mb-2w">S’aligner sur le cadre d’intervention de la Brigade en définissant les objectifs et les indicateurs d’impact attendu.</p>
 
-            <a class="fr-btn fr-btn--md fr-mt-2w" href="mailto:brigade@beta.gouv.fr">Proposer un sujet à la Brigade - nouvelle fenêtre</a>
+            <a class="fr-btn fr-btn--md fr-mt-2w" href="mailto:brigade@beta.gouv.fr" title="Proposer un sujet à la Brigade - nouvelle fenêtre">Proposer un sujet à la Brigade</a>
           </div>
         </div>
 


### PR DESCRIPTION
Lors d'une PR sur l'a11y je me suis emmêlée les pinceaux et au lieu d'ajouter la mention "nouvelle fenêtre" dans le title d'un lien je l'ai ajouté directement au bouton.
Je corrige donc cette erreur. 