### PR TITLE
ci: install and cache dependencies with built-in actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,18 +16,13 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
-    - uses: actions/cache@v2
-      with:
-        path: |
-          vendor/bundle
-          ~/.local
-          ~/.cache
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
+        ruby-version: 3.1
+        bundler-cache: true
     - name: Install npm dependencies
-      run: npm install
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'npm'
 
     - uses: actions/setup-python@v2
       with:
@@ -35,8 +30,6 @@ jobs:
     - name: Install python dependencies
       run: pip3 install -r requirements.txt
 
-    - name: Install dependencies
-      run: bundle check || bundle install --path vendor/bundle
     - name: Unit tests
       run: ruby -e "Dir.glob('rb/test/*.rb').each { |f| require File.expand_path(f) }"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,8 @@ jobs:
       with:
         node-version: 16
         cache: 'npm'
+    - run: npm ci
+
 
     - uses: actions/setup-python@v2
       with:

--- a/rb/bin/validate
+++ b/rb/bin/validate
@@ -17,7 +17,7 @@ list        = Rake::FileList[list_path]
 puts("Running #{schema_path} on #{list_path}…")
 
 error_count = list.reduce(0) do |acc, file_path|
-  document = YAML.load_file(file_path)
+  document = YAML.unsafe_load_file(file_path)
   errors = validator.validate(document)
 
   next(acc) unless errors && !errors.empty?


### PR DESCRIPTION
Both setup-node and setup-ruby offer built-in caching, which is always
better than us doing it ourselves (ruby deps) or not doing it all (npm
deps).
