### PR TITLE
Répare label techno pour les jobs

### DIFF
--- a/_includes/card-job.html
+++ b/_includes/card-job.html
@@ -53,7 +53,7 @@ Ex : {% include card-job.html job = job %}
           <ul class="fr-tags-group fr-my-1w">
             {% for techno in job.techno %}
               <li>
-                <p class="fr-tag">{{ job.techno }}</p>
+                <p class="fr-tag">{{ techno }}</p>
               </li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
Quand on indique une liste de technologies, on obtient un rendu étonnant. La mauvaise variable est utilisée dans le template actuellement, cette PR corrige ceci.

![image](https://user-images.githubusercontent.com/295709/185406531-3dba1deb-1d71-4bb0-b846-37aef0a4f19a.png)
