### PR TITLE
Mise à jour de la fiche pour guillaume.lagorce. Référent : jeremy.buget

### DIFF
--- a/content/_authors/guillaume.lagorce.md
+++ b/content/_authors/guillaume.lagorce.md
@@ -7,6 +7,10 @@ missions:
   - start: 2019-01-01
     end:  2020-02-29
     status: independent
+  - start: 2022-09-06
+    end: 2022-10-28
+    status: independent
 startups:
+    - carnet.de.bord
     - trait-d-union
 ---


### PR DESCRIPTION
Très heureux de revenir au sein de beta.gouv.

Je retrouve l'incubateur au sein de Carnet de Bord.

A bientôt!