### PR TITLE
Correction lien vers grille BetaGouv

### DIFF
--- a/content/_jobs/2022-08-01-business-developer-monservicesecurise.md
+++ b/content/_jobs/2022-08-01-business-developer-monservicesecurise.md
@@ -62,7 +62,7 @@ Une connaissance de l’administration publique et du travail au contact d'agent
 * Poste ouvert pour un· indépendant·e pour un premier contrat de 6 mois renouvelable, 4/5 par semaine.
 * Poste en télétravail avec réunions ponctuelles de l’équipe
 * Démarrage en septembre. 
-* Rémunération : à discuter (<a href="https://doc.incubateur.net/communaute/travailler-a-beta-gouv/jutilise-les-outils-de-la-communaute/welcome-to-the-jungle">voir grille indicative</a>)
+* Rémunération : à discuter (<a href="https://doc.incubateur.net/communaute/gerer-sa-startup-detat-ou-de-territoires-au-quotidien/decouvrir-les-differents-metiers-dune-startup-detat/recrutement/conseils-pour-le-recrutement/observatoire-revenus#les-tjm-une-base-pour-evaluer-le-prix-dune-prestation">voir grille indicative</a>)
 * Pour candidater, postulez <a href="https://www.welcometothejungle.com/fr/companies/communaute-beta-gouv/jobs/business-developer_paris">ici</a>
 
 À bientôt ! 😀


### PR DESCRIPTION
Erreur de lien, qui renvoyait vers une autre page de doc.incubateur

## Mise à jour de date de mission

Pour une simple mise à jour de dates de mission, si tu as les droits, tu peux merger toi-même sans relecture (tu auras juste à attendre 1-2 mins pour les tests passent)  
PS : Ne t'attends pas à ce qu'on le fasse pour toi !

## Publication

Pour des modifications de contenu : `beta.gouv.fr` est un site officiel, tu dois être pleinement consciente que les élasticités règlementaires qui nous permettent de fonctionner ne peuvent exister qu'avec une forme d'auto-régulation. **Demandes l'avis de membres plus anciens que vous avant de publier du contenu.**
Vous pouvez le faire sur Mattermost ici : https://mattermost.incubateur.net/betagouv/channels/incubateur-help
