### PR TITLE
Met à jour le lien incubateur des fiches produit pour pointer vers leur description plutôt que la liste des équipes accompagnées

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -29,9 +29,9 @@ layout: default
 
 {% capture incubator_info %}
 {% if phase.status == 'success' %}
-  L'équipe a été portée par <a href="/startups/?incubateur={{ incubator_id | remove: '/incubators/' }}" title="{{ incubator.title }}">{{ incubator.title }}</a>
+  L'équipe a été portée par <a href="/communaute/#{{ incubator_id}}" title="{{ incubator.title }}">{{ incubator.title }}</a>
 {% else %}
-  L'équipe est portée par <a href="/startups/?incubateur={{ incubator_id | remove: '/incubators/' }}" title="{{ incubator.title }}">{{ incubator.title }}</a>
+  L'équipe est portée par <a href="/communaute/#{{ incubator_id}}" title="{{ incubator.title }}">{{ incubator.title }}</a>
 {% endif %}
 {% endcapture %}
 


### PR DESCRIPTION
Par exemple sur

https://beta.gouv.fr/startups/chantiers.agiles.html

Actuellement, on a
> L'équipe est portée par [GIP Plateforme de l'inclusion](https://beta.gouv.fr/startups/?incubateur=gip-inclusion)

ie. on redirige vers https://beta.gouv.fr/startups/?incubateur=gip-inclusion.

Avec cette PR on redirige vers https://beta.gouv.fr/communaute/#/incubators/gip-inclusion.
