### PR TITLE
Editition des fiches produits du GIP de la Plateforme de l'inclusion.

### DIFF
--- a/content/_startups/inclusion.connect.md
+++ b/content/_startups/inclusion.connect.md
@@ -13,8 +13,15 @@ phases:
   - name: construction
     start: 2022-07-01
     comment: Produit fonctionnel et déployé sur des premiers services
+user_profiles:
+  - "Collectivités"
+  - "Employeurs solidaires"
+  - "Professionels de l'insertion"
+  - "Services de l'Etat"
+themes:
+  - "Authentification unique"
 ---
-## Problème
+## Le problème
 
 Les services numériques à destination des professionnels de l’inclusion se multiplient, et avec eux les identifiants et mots de passe. Pour les usagers cela devient complexe et fastidieux et présente de vrais risques de sécurité.
 


### PR DESCRIPTION
Dans le cadre de la refonte du site du GIP de la Plateforme de l'inclusion, nous avons décidé de conserver les fiches produit de BetaGouv comme source de vérité unique.

Pour des besoins de rendu, nous devons adapter les fiches en uniformisant la structure ("## Le problème", "## Notre srvice").

Par ailleurs, nous les agrémentons de données meta pour pouvoir proposer un filtre sur les équipes : 
- `user_profiles` (7~8 options prédéfinies)
- `themes` (~7 options prédéfinies)