### PR TITLE
Ajout de nouveau "types d'utilisateurs" (propriété `usertypes` dans le schéma de données des `startups`)

### DIFF
--- a/schema/startups.yml
+++ b/schema/startups.yml
@@ -172,6 +172,9 @@ mapping:
             - entreprise
             - association
             - etablissement-scolaire
+            - editeur-logiciel
+            - professionnel-de-l-insertion
+            - employeur-solidaire
   "analyse_risques":
     type:      bool
   "analyse_risques_url":


### PR DESCRIPTION
## 🍣 Contexte / problème

Dans le cadre du développement du site vitrine institutionnel du GIP Plateforme de l'inclusion, nous avons fait le choix technique stratégique de se baser un maximum sur les données du site de BetaGouv et d'en faire la source principale de vérité, en tout cas dans un premier temps.

A moyen / long terme, il paraît plus judicieux que ce soit le GIP qui soit le Référent de sa propre donnée, mais avec un mécanisme permettant de synchroniser (batch, webhook, autre) les données de description des produits adaptés au modèle et vers BetaGouv.

Parmi les *fonctionnalités* que nous souhaitons mettre en avant sur le site, et dans la veine de ce qui est fait sur le site de BetaGouv, nous aimerions proposer des filtres sur les différents produits du GIP : 
- phase → propriété `phase`, exploitable en l'état
- profil utilisateur → propriété `userypes`, à compléter pour les typologies d'utilisateurs du GIP non encore définies par BetaGouv
- thématique → pas de propriété définie dans le schéma BetaGouv

## 🪄 Proposition / solution

Pour une V1 rapide et pas chère, nous décidons de faire l'impasse sur le filtre "Thématique(s)". Nous pensons que l'ajout d'une telle propriété ne passerait pas (à juste titre) auprès de la communauté BetaGouv.

Pour le filtre "Profil(s) utilisateur", nous pensons pouvoir nous en sortir avec la propriété `usertypes` existante.

L'objet de cette PR consiste à proposer 3 nouvelles valeurs, que nous avons tenté de formuler de façon suffisamment générique et utile pour le reste des startups de l'incubateur. 

- autant pour l'option `editeur-logiciel` je pense que c'est assez simple. 
- j'espère avoir été suffisamment générique pour les options `professionnel-de-l-insertion` et `employeur-solidaire` qui restent malgré tout très teinté "Domaine de l'inclusion"

<img width="645" alt="image" src="https://user-images.githubusercontent.com/265963/215830228-30f5596f-72c1-447b-ac3f-776c5897a56e.png">


> NDLA : ça fait beaucoup de description pour seulement 3 valeurs, mais la décision ou la direction suivie me semblent le justifier 😅