### PR TITLE
répare le lien vers la doc pour créer un compte github depuis la page d’accueil Netlify CMS

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -129,7 +129,7 @@
           onTheFlyAuthenticationElem.innerHTML = `<p>
             <h1>Bonjour,</br>
             Bienvenue sur l'admin beta.gouv.fr.</br></br></h1>
-            Après t'être connecté via Github, tu pourras :  </br><small>(si tu n'as pas de compte github tu peux voir la <a target="_blank" style="text-decoration: underline" href="https://doc.incubateur.net/communaute/outils/github">doc</a> pour t'en créer un)</small></br></br>
+            Après t'être connecté via Github, tu pourras :  </br><small>(si tu n'as pas de compte github tu peux voir la <a target="_blank" style="text-decoration: underline" href="https://doc.incubateur.net/communaute/travailler-a-beta-gouv/jutilise-les-outils-de-la-communaute/github">doc</a> pour t'en créer un)</small></br></br>
             <ul>
               <li>ajouter ou éditer une fiche produit</li>
               <li>éditer une fiche membre</li>


### PR DESCRIPTION
il s’agit de ce lien

<img width="614" alt="Screenshot 2023-02-15 at 17 32 16" src="https://user-images.githubusercontent.com/883348/219093761-ed342790-8f10-4d6c-9057-27fca6f0fbc7.png">
