### PR TITLE
git workflow - change ubuntu-18.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/sync-authors-to-blog.yml
+++ b/.github/workflows/sync-authors-to-blog.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Sync
       uses: adrianjost/files-sync-action@v1.0.1


### PR DESCRIPTION
Bug fix pour l'action `sync` qui semble ne plus marcher : https://github.com/betagouv/beta.gouv.fr/actions/runs/4344519370

