### PR TITLE
[CI] Passer à Ubuntu 22.04 sur Github Actions

### DIFF
--- a/.github/workflows/sync-authors-to-blog.yml
+++ b/.github/workflows/sync-authors-to-blog.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Sync
       uses: adrianjost/files-sync-action@v1.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
La version 18.04 est dépréciée, donc pourquoi pas prendre de l'avance et passer à 22.04 ! :dancers: 