### PR TITLE
Correction offre recrutement

### DIFF
--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -55,7 +55,7 @@ menu:
             {% assign jobs = site.jobs | where: "open", 'true' |  where_exp:"item", "item.domaines contains page.domaine" | where_exp: "item", "item.depublication_date == null or item.depublication_date > site.time" | sort: "date" | reverse %}
           {% endif %}
           {% if jobs.size == 0 %}
-            <center><h3 class="fr-card__title" style="margin-top: 20px">Il n'y a pas d'offres pour ce domaine actuellement.</h3></center>
+            <center><h3 class="fr-card__title" style="margin-top: 20px">Toutes nos offres sont sur Welcome to the Jungle.</h3></center>
           {% endif %}
 
           {% for job in jobs %}


### PR DESCRIPTION
- remplacer "il n'y a pas d'offre" par "aller voir sur WTTJ"
