### PR TITLE
bercy.md : ajout mot manquant et correction typo

### DIFF
--- a/content/_incubators/bercy.md
+++ b/content/_incubators/bercy.md
@@ -8,4 +8,4 @@ contact: mailto:amd@finances.gouv.fr?subject=Incubateur_MEFR
 address: 139 rue de Bercy, Paris 12e
 ---
 
-Créé fin 2019, l'incubateur du MEFR propose un cadre d'innovaton numérique qui utilisateurs et métiers au centre. L'incubateur fournit aux intrapreneurs du ministère des ressources communes ou dédiées. Il accueille aussi apprentis et jeunes experts en première expérience professionnelle.
+Créé fin 2019, l'incubateur du MEFR propose un cadre d'innovation numérique qui place utilisateurs et métiers au centre. L'incubateur fournit aux intrapreneurs du ministère des ressources communes ou dédiées. Il accueille aussi apprentis et jeunes experts en première expérience professionnelle.


### PR DESCRIPTION
Sur la page de description de l’incubateur du MEFR (Bercy), on lisait ceci : 

> _[…] propose un cadre d’innovaton numérique qui utilisateurs et métiers […]_

Un **«i»** manquait à **« innovation »**, et un mot manquait entre **« qui utilisateurs »** (je propose **« place »**, qui semble bien adapté).
