### PR TITLE
Change le lien de candidature spontanée

### DIFF
--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -90,7 +90,7 @@ menu:
 <section class="fr-py-6w section-grey">
   <div class="fr-container">
     <div class="fr-mb-5v">
-      <a class="fr-btn" href="https://airtable.com/shrzxJlITsisv09L6" target="_blank" title="Candidature spontanée - nouvelle fenêtre " rel="noopener">Candidature spontanée</a>
+      <a class="fr-btn" href="https://www.welcometothejungle.com/fr/companies/communaute-beta-gouv/jobs/candidatures-spontanees" target="_blank" title="Candidature spontanée - nouvelle fenêtre " rel="noopener">Candidature spontanée</a>
       <a href="/jobs.xml" class="fr-link" title="Flux RSS Atom - nouvelle fenêtre" target="_blank" rel="noopener">
         Souscrire au flux RSS
       </a>

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -48,7 +48,7 @@ Nous pouvons vous aider à organiser cet évènement interne, sélectionner les 
 
 ## Rejoindre les équipes de beta.gouv.fr
 
-Consultez notre [page Recrutement](/recrutement) ou transmettez nous une candidature spontanée à recrutement@beta.gouv.fr. 
+Consultez notre [page Recrutement](/recrutement) ou transmettez nous une [candidature spontanée](https://www.welcometothejungle.com/fr/companies/communaute-beta-gouv/jobs/candidatures-spontanees). 
 Vous pouvez aussi nous suivre sur Twitter à [@BetaGouv](https://twitter.com/BetaGouv).
 
 ## Proposer une idée de service public numérique


### PR DESCRIPTION
Je propose de changer le lien de candidature spontannée par celui de welcome to the jungle : https://www.welcometothejungle.com/fr/companies/communaute-beta-gouv/jobs/candidatures-spontanees
J'ai aussi redirigé dans contact la mention de candidature spontanée vers le même formulaire.

Je propose aussi de fermer le airtable (je ne crois plus qu'il soit utilisé).
