### PR TITLE
Correction de l'identifiant de startup dans forster.groux.md

### DIFF
--- a/content/_authors/forster.groux.md
+++ b/content/_authors/forster.groux.md
@@ -14,7 +14,7 @@ missions:
     employer: /ut7
 startups:
   - ma-cantine-egalim
-  - Cassiopée
+  - cassiopee
 ---
 
 Développeur passionné d'agilité et d'horizontalité


### PR DESCRIPTION
J'ai mergé un peu vite #15525 sans faire attention au fait que l'id de startup était écrit `Cassiopée` au lieu de `cassiopee` comme on trouve dans https://beta.gouv.fr/api/v2.5/startups.json .