### PR TITLE
Fiche startup : répare une typo et un espace manquant

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -210,7 +210,7 @@ layout: default
               {% endif %}
               {{ transparence_success }}
               {% if page.techno %}
-              <li><span class="fr-icon-computer-line"></span>Technoligies utilisées :
+              <li><span class="fr-icon-computer-line"></span>Technologies utilisées :
                 {{ page.techno | join: " - " }}
               </li>
               {% endif %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -122,9 +122,11 @@ layout: default
                 {% if page.repository.size > 0 %}
                 <span class="fr-icon-github-fill"></span>
                 <a class="fr-link" href="{{ page.repository }}">
-                  Code source</a>
+                  Code source
+                </a>
                 {% else %}
-                <span class="fr-icon-github-fill"></span><a class="fr-link" aria-disabled="true" >
+                <span class="fr-icon-github-fill"></span>
+                <a class="fr-link" aria-disabled="true" >
                   Code source (non disponible)
                 </a>
                 {% endif %}
@@ -210,7 +212,9 @@ layout: default
               {% endif %}
               {{ transparence_success }}
               {% if page.techno %}
-              <li><span class="fr-icon-computer-line"></span>Technologies utilisées :
+              <li>
+                <span class="fr-icon-computer-line"></span>
+                Technologies utilisées :
                 {{ page.techno | join: " - " }}
               </li>
               {% endif %}


### PR DESCRIPTION
### Sur la fiche startup

Modifications apportées : 
- il y avait une typo sur "Technologies"
- il manquait un espace entre l'icone et le mot
- j'ai aussi fait une mini-modif sur le formattage du html

### Captures d'écran

exemple : https://beta.gouv.fr/startups/ecobalyse.html

|Avant|Après|
|---|---|
|![image](https://github.com/betagouv/beta.gouv.fr/assets/7147385/8b9fdd77-70d9-4cba-ad65-7a01d6d66031)|![image](https://github.com/betagouv/beta.gouv.fr/assets/7147385/47a3ae00-93a1-49e2-a883-3a109f79fdde)|


