### PR TITLE
Update maiwelle.mezi.md

### DIFF
--- a/content/_authors/maiwelle.mezi.md
+++ b/content/_authors/maiwelle.mezi.md
@@ -7,7 +7,7 @@ missions:
     end: 2024-04-28
     status: independent
     employer: Malt 
-startups:
+previously:
   - jeveuxaider
   - api-engagement
 badges:


### PR DESCRIPTION
## Mise à jour de date de mission

Maiwelle a quitté la startup Engagement Civique (JeVeuxAider.gouv.fr et API Engagement) le 12 mai 2023. Mise à jour donc de son profil. 
