### PR TITLE
Met à jour la date de fin de mission de Sandra Chakroun

### DIFF
--- a/content/_authors/sandra.chakroun.md
+++ b/content/_authors/sandra.chakroun.md
@@ -6,7 +6,7 @@ link: https://www.linkedin.com/in/sandra-chakroun
 github: sandcha
 missions:
   - start: 2017-05-10
-    end: 2023-11-01
+    end: 2024-01-31
     status: independent
     employer: octo
 startups:


### PR DESCRIPTION
Présence jusqu'à janvier, principalement pour l'investigation Réformes Locales.


- - - -
> ## Mise à jour de date de mission
> 
> Pour une simple mise à jour de dates de mission, si tu as les droits, tu peux merger toi-même sans relecture (tu auras juste à attendre 1-2 mins pour les tests passent)  
> PS : Ne t'attends pas à ce qu'on le fasse pour toi !
