### PR TITLE
charles.capelli - Correction de l'année (erreur)

### DIFF
--- a/content/_authors/charles.capelli.md
+++ b/content/_authors/charles.capelli.md
@@ -5,7 +5,7 @@ domaine: Développement
 github: Scttpr
 missions:
   - start: 2022-02-22
-    end: 2023-05-30
+    end: 2024-05-30
     status: service
     employer: Incubateur des territoires
 previously:
@@ -15,5 +15,3 @@ competences:
   - Infosec
   - Devops
 ---
-
-


### PR DESCRIPTION
Il y avait une erreur dans l'année, qui a déclenché la fermeture des accès de Charles.