### PR TITLE
Mise à jour fiche Célia Hanssen

### DIFF
--- a/content/_authors/celia.hanssen.md
+++ b/content/_authors/celia.hanssen.md
@@ -5,7 +5,7 @@ domaine: Autre
 link: https://omnicite.fr/
 missions:
   - start: 2021-09-27
-    end: 2022-12-30
+    end: 2024-12-31
     status: service
     employer: LaZone
 ---


### PR DESCRIPTION
Extension de la date de fin de mission pour que Célia puisse de nouveau accéder à Mattermost et contacter ses interlocutrices et interlocuteurs.