### PR TITLE
Utilisation du tiret dans le nom de la Start-up

### DIFF
--- a/content/_startups/portail-rse.md
+++ b/content/_startups/portail-rse.md
@@ -12,6 +12,7 @@ dashlord_url: https://dashlord.incubateur.net/url/impact-beta-gouv-fr/
 accessibility_status: non conforme
 redirect_from:
   - /startups/plateforme.impact.html
+  - /startups/portail.rse.html
 phases:
   - name: investigation
     start: 2022-01-02


### PR DESCRIPTION
Après discussion sur Mattermost, utiliser le tiret dans l'URL semble être le futur (et correspond plus au sous-domaine utilisé par le service)