### PR TITLE
Optimisation taille d'image Scalingo

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,6 +1,7 @@
 node_modules
 img
-vendor
+vendor/ruby*
+vendor/bundle
 .jekyll-cache
 .scalingo
 content

--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,6 @@
+node_modules
+img
+vendor
+.jekyll-cache
+.scalingo
+content


### PR DESCRIPTION
##  Problème
L'image scalingo fait 638Mo, ça créé beaucoup d'over-head sur le déplois

## Solution
Suppression des fichies inutiles pour les run de l'app.
La taillle de l'image devient réduite à 242Mo