### PR TITLE
Update carnet.de.bord.md

### DIFF
--- a/content/_startups/carnet.de.bord.md
+++ b/content/_startups/carnet.de.bord.md
@@ -21,8 +21,6 @@ stats_url: >-
   https://matomo-metabase-carnetdebord.fabrique.social.gouv.fr/public/dashboard/81a749aa-6c29-46b2-9ca5-df9d90fd3257
 events: []
 phases:
-  - name: alumni
-    start: 2023-12-01
   - name: investigation
     start: 2021-01-25
     end: 2021-05-06
@@ -32,6 +30,8 @@ phases:
   - name: acceleration
     start: 2021-11-01
     end: 2022-04-30
+  - name: alumni
+    start: 2023-12-01
 ---
 
 # 2024 - Pause dans le développement du service numérique 


### PR DESCRIPTION
La phase alumni est en cours et doit donc être en bas de la liste pour que le service apparaisse bien comme "Produit en partenariats terminés" sur le site beta.gouv.fr . Actuellement, le service apparaît encore en accélération :

![image](https://github.com/betagouv/beta.gouv.fr/assets/17601807/8913d7bc-a37b-4f45-ab90-99bcf731ae54)

J'ai également besoin que cette phase soit la dernière pour la synchro vers le site de la plateforme de l'inclusion.

cc @vviers @amaurydubot 