### PR TITLE
Simplification de l'annuaire

### DIFF
--- a/_includes/line-community.html
+++ b/_includes/line-community.html
@@ -23,7 +23,7 @@
     <td>{{ author.role }}</td>
     <td>
       <ul class="fr-tags-group">
-        {% for startup in startups, limit: 5 %}
+        {% for startup in startups, limit: 10 %}
           {% assign startup_id = "/startups/" | append: startup %}
           {% assign this_startup = site.startups | find: "id", startup_id %}
           {% if this_startup %}
@@ -34,7 +34,7 @@
             {% continue %}
           {% endif %}
         {% endfor %}
-        {% for startup in previously, limit: 5 %}
+        {% for startup in previously, limit: 10 %}
           {% assign startup_id = "/startups/" | append: startup %}
           {% assign this_startup = site.startups | find: "id", startup_id %}
           {% if this_startup %}

--- a/_includes/line-community.html
+++ b/_includes/line-community.html
@@ -39,7 +39,7 @@
           {% assign this_startup = site.startups | find: "id", startup_id %}
           {% if this_startup %}
             <li>
-              <a class="fr-tag" aria-disabled="true" href="{{ this_startup.url }}" target="_self">{{ this_startup.title }}</a>
+              <a class="fr-tag" aria-disabled="true">{{ this_startup.title }}</a>
             </li>
           {% else %}
             {% continue %}

--- a/_includes/line-community.html
+++ b/_includes/line-community.html
@@ -1,0 +1,50 @@
+{%- comment -%}
+  Appeler cette page avec un author
+  Ex : {%- include line-community.html author=author -%}
+{%- endcomment -%}
+
+{%- assign author= include.author -%}
+
+{%- comment -%}
+  Détecter si l'author est actif ou non. Par défaut, oui.
+{%- endcomment -%}
+
+{% assign empty_array = "" | split: "," %}
+{% assign startups = author.startups | default: empty_array %}
+{% assign previously = author.previously | default: empty_array %}
+
+<tr>
+    <td>{% if author.link.size > 0 %}
+            <a href="{{ author.link }}" target="_blank" rel="noopener" title="Site web de {{author.fullname}} - nouvelle fenêtre">{{ author.fullname }}</a>
+          {% else %}
+            {{ author.fullname }}
+          {% endif %}
+      </td>
+    <td>{{ author.role }}</td>
+    <td>
+      <ul class="fr-tags-group">
+        {% for startup in startups, limit: 5 %}
+          {% assign startup_id = "/startups/" | append: startup %}
+          {% assign this_startup = site.startups | find: "id", startup_id %}
+          {% if this_startup %}
+            <li>
+              <a class="fr-tag" href="{{ this_startup.url }}" target="_self">{{ this_startup.title }}</a>
+            </li>
+          {% else %}
+            {% continue %}
+          {% endif %}
+        {% endfor %}
+        {% for startup in previously, limit: 5 %}
+          {% assign startup_id = "/startups/" | append: startup %}
+          {% assign this_startup = site.startups | find: "id", startup_id %}
+          {% if this_startup %}
+            <li>
+              <a class="fr-tag" aria-disabled="true" href="{{ this_startup.url }}" target="_self">{{ this_startup.title }}</a>
+            </li>
+          {% else %}
+            {% continue %}
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </td>
+</tr>

--- a/_layouts/annuaire.html
+++ b/_layouts/annuaire.html
@@ -3,7 +3,6 @@ layout: default
 ---
 
 {%- assign currents = site.authors | community: 'current', 'oldest' -%}
-{%- assign alumnis = site.authors | community: 'past', 'oldest' -%}
 {% assign lang = page.lang | default: site.lang | default: "en" %}
 {% assign incubators = site.incubators %}
 <script>
@@ -29,34 +28,6 @@ layout: default
                 ],
                 "previously": [
                     {% for previous_startup in current.previously %}
-                        "{{ previous_startup }}",
-                    {% endfor %}
-                ],
-            }
-        {% unless forloop.last %},{% endunless %}
-        {% endfor %}
-    ];
-    var alumnis = [
-        {% for alumni in alumnis %}
-            { "id"        : "{{ alumni.id }}",
-                "fullname": "{{ alumni.fullname}}",
-                "link": "{{ alumni.link }}",
-                "role": `{{ alumni.role | escape }}`,
-                {% if alumni.github %} "github": "{{ alumni.github }}",{% endif %}
-                {% if alumni.avatar %} "avatar": "{{ alumni.avatar }}",{% endif %}
-                "content" : `{{ alumni.content | escape  }}`,
-                "missions": [
-                    {% for mission in alumni.missions %}
-                        { "start": "{{mission.start}}", "end": "{{mission.end}}", "status": "{{mission.status}}", "employer": "{{mission.employer}}" }{% unless forloop.last %},{% endunless %}
-                    {% endfor %}
-                ],
-                "startups": [
-                    {% for startup in alumni.startups %}
-                        "{{ startup }}",
-                    {% endfor %}
-                ],
-                "previously": [
-                    {% for previous_startup in alumni.previously %}
                         "{{ previous_startup }}",
                     {% endfor %}
                 ],
@@ -142,30 +113,25 @@ layout: default
             </select>
         </div>
     </section>
-    <div class="fr-tabs">
-        <ul class="fr-tabs__list" role="tablist" aria-label="Changer de vue">
-            <li role="presentation">
-                <button id="tabpanel-actifs-button" class="fr-tabs__tab" tabindex="0" role="tab" aria-selected="true" aria-controls="tabpanel-actifs">Membres actifs</button>
-            </li>
-            <li role="presentation">
-                <button id="tabpanel-alumnis-button" class="fr-tabs__tab" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-alumnis">Alumni</button>
-            </li>
-        </ul>
-        <div id="tabpanel-actifs" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-actifs-button" tabindex="0">
-            <h2><span id="currents-count">{{ currents | size }}</span> membres actifs</h2>
-            <div class="authors fr-grid-row fr-grid-row--gutters">
-                {%- for author in currents -%}
-                <div class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">{%- include card-community.html author=author -%}</div>
-                {%- endfor -%}
-            </div>
-        </div>
-        <div id="tabpanel-alumnis" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-alumnis-button" tabindex="-1">
-            <h2><span id="alumnis-count">{{ alumnis | size }}</span> alumni</h2>
-            <div class="alumnis fr-grid-row fr-grid-row--gutters">
-                {%- for author in alumnis -%}
-                <div class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">{%- include card-community.html author=author -%}</div>
-                {%- endfor -%}
-            </div>
+    
+    <h2><span id="currents-count">{{ currents | size }}</span> membres actifs</h2>
+    <div class="authors fr-grid-row fr-grid-row--gutters">
+        <div class="fr-table fr-table--no-caption">
+            <table>
+                <caption>Membres de la communauté</caption>                    
+                <thead>
+                    <tr>
+                        <th scope="col">Nom </th>
+                        <th scope="col">Rôle </th>
+                        <th scope="col">Équipe</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {%- for author in currents -%}
+                        {%- include line-community.html author=author -%}
+                    {%- endfor -%}
+                </tbody>
+            </table>
         </div>
     </div>
 </div>

--- a/_layouts/annuaire.html
+++ b/_layouts/annuaire.html
@@ -113,9 +113,10 @@ layout: default
             </select>
         </div>
     </section>
+
     
     <h2><span id="currents-count">{{ currents | size }}</span> membres actifs</h2>
-    <div class="authors fr-grid-row fr-grid-row--gutters">
+    <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-table fr-table--no-caption">
             <table>
                 <caption>Membres de la communauté</caption>                    
@@ -126,7 +127,7 @@ layout: default
                         <th scope="col">Équipe</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody class="authors">
                     {%- for author in currents -%}
                         {%- include line-community.html author=author -%}
                     {%- endfor -%}

--- a/assets/additional/js/search-member.js
+++ b/assets/additional/js/search-member.js
@@ -22,8 +22,7 @@ function convertDate(inputFormat) {
 }
 
 var createAuthorCard = function (author) {
-  var card = document.createElement("div");
-  card.className = "fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3";
+  var card = document.createElement("tr");
   card.id = author.id;
   var totalStartups = [];
   if (author.startups) {
@@ -75,30 +74,14 @@ function markupForCard(params) {
   const { title, detail, content, tags, other, avatar } = params;
 
   return `
-<div class="fr-card fr-card--grey">
-  <div class="fr-card__body">
-    <div class="fr-card__content">
-      <div class="fr-card__start">
-    <h3 class="fr-card__title fr-mb-2w">
-      ${title}
-    </h3>
-    <p class="fr-card__detail">
-      ${detail}
-    </p>
-    ${content ? '<p class="fr-card__desc">' + content + "</p>" : ""}
+<tr>
+  <td>${title}</td>
+  <td>${detail}</td>
+  <td>
     ${tags ? '<ul class="fr-tags-group">' + tags + "</ul>" : ""}
     ${!!other ? '<p class="fr-card__detail">' + other + "</p>" : ""}
-  </div>
-</div>
-</div>
-<div class="fr-card__header">
-  <div class="fr-card__img">
-    <div class="avatar fr-py-2w">
-      ${avatar}
-    </div>
-  </div>
-</div>
-</div>`;
+  </td>
+</tr>`;
 }
 
 var generateDataWithHtmlCards = function (members) {

--- a/assets/additional/js/search-member.js
+++ b/assets/additional/js/search-member.js
@@ -120,11 +120,12 @@ var createIncubatorSelect = function (members, incubators, initValue) {
       ...d,
       html: createAuthorCard(d),
     }));
-    var alumnisToDisplay = alumnis.filter((alumni) => intersection(alumni.startups, selectedStartups) || alumni.incubator === value);
-    alumnisToDisplay = alumnisToDisplay.map((d) => ({
-      ...d,
-      html: createAuthorCard(d),
-    }));
+    // var alumnisToDisplay = alumnis.filter((alumni) => intersection(alumni.startups, selectedStartups) || alumni.incubator === value);
+    // alumnisToDisplay = alumnisToDisplay.map((d) => ({
+    //   ...d,
+    //   html: createAuthorCard(d),
+    // }));
+
     var documentFragmentCurrents = document.createDocumentFragment();
     for (var j = 0; j < currentsToDisplay.length; j++) {
       documentFragmentCurrents.appendChild(currentsToDisplay[j].html);
@@ -135,15 +136,15 @@ var createIncubatorSelect = function (members, incubators, initValue) {
     var countCurrentsElement = document.getElementById("currents-count");
     countCurrentsElement.innerHTML = currentsToDisplay.length;
 
-    var documentFragmentAlumnis = document.createDocumentFragment();
-    for (var j = 0; j < alumnisToDisplay.length; j++) {
-      documentFragmentAlumnis.appendChild(alumnisToDisplay[j].html);
-    }
-    var gridAlumnis = document.getElementsByClassName("alumnis")[0];
-    gridAlumnis.innerHTML = "";
-    gridAlumnis.appendChild(documentFragmentAlumnis);
-    var countAlumnisElement = document.getElementById("alumnis-count");
-    countAlumnisElement.innerHTML = alumnisToDisplay.length;
+    // var documentFragmentAlumnis = document.createDocumentFragment();
+    // for (var j = 0; j < alumnisToDisplay.length; j++) {
+    //   documentFragmentAlumnis.appendChild(alumnisToDisplay[j].html);
+    // }
+    // var gridAlumnis = document.getElementsByClassName("alumnis")[0];
+    // gridAlumnis.innerHTML = "";
+    // gridAlumnis.appendChild(documentFragmentAlumnis);
+    // var countAlumnisElement = document.getElementById("alumnis-count");
+    // countAlumnisElement.innerHTML = alumnisToDisplay.length;
 
     if (window.lozad) {
       const observer = lozad();

--- a/assets/additional/js/search-member.js
+++ b/assets/additional/js/search-member.js
@@ -31,7 +31,7 @@ var createAuthorCard = function (author) {
   if (author.previously) {
     totalStartups = totalStartups.concat(author.previously);
   }
-  totalStartups = totalStartups.slice(0, 4);
+  totalStartups = totalStartups.slice(0, 10);
 
   let timestampNow = new Date();
   let authorEndDate;


### PR DESCRIPTION
Avant : on affichait sur la même page 1272 membres actifs + 1161 membres alumnis. Et pour chacun de ces membres, on affichait un avatar. 
Résultat : la page est extrêmement longue et complexe (note G sur l'écoxindex, elle fait planter certains navigateur ou téléphone) 😬
![image](https://github.com/betagouv/beta.gouv.fr/assets/1374389/6193c3b5-c941-4b76-b04a-8471d09076fe)


Dans cette proposition : 
- on affiche plus les alumnis (ça pourrait être une page dédiée)
- on affiche plus les avatars (ils restent sur les fiches produits)
- on affiche plus la bio (elle est peu renseignée)
- on affiche les personnes de la communauté dans un simple tableau de 3 colonnes : nom, rôle et SE (courantes et passées)
- on distingue aussi les anciennes startups des actuelles.
La page est ainsi beaucoup plus légère (ça reste une mauvaise note à l'écoindex, mais il faudrait mettre en place une pagination pour faire mieux).

![image](https://github.com/betagouv/beta.gouv.fr/assets/1374389/1c225dc9-f0b8-4b8e-8d77-e7b8ad2d37ac)

(PS : le code `search-member.js` est dégueu : il duplique du code de template. Je me demande si on pouvait pas simplement faire du display-none sur les éléments à cacher plutôt que de ré-ecrire tout le html... Mais bon, ça dépasse mes compétences donc je ne change pas le fonctionnement existant dans cette PR)

