### PR TITLE
Corrections d'accessibilité

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,9 +1,11 @@
 ---
 social:
 -
+  name: Linkedin
   icon: linkedin-box
   url: https://www.linkedin.com/company/betagouv/
 -
+  name: Github
   icon: github
   url: https://www.github.com/betagouv
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,8 +20,8 @@
           <ul class="fr-btns-group fr-btns-group--lg">
             {% for item in site.data.footer.social %}
               <li>
-                <a class="fr-icon-{{ item.icon }}-fill fr-btn" href="{{ item.url }}" target="_blank" title="Profil {{ item.icon | capitalize }} de BetaGouv - nouvelle fenêtre">
-                  {{ item.icon }}</a>
+                <a class="fr-icon-{{ item.icon }}-fill fr-btn" href="{{ item.url }}" target="_blank" title="Profil {{ item.name | capitalize }} de BetaGouv - nouvelle fenêtre">
+                  {{ item.name }}</a>
               </li>
               {% endfor %}
           </ul>

--- a/_layouts/incubateurs.html
+++ b/_layouts/incubateurs.html
@@ -34,32 +34,32 @@ layout: default
                 <div class="fr-col">
                     <ul class="checkmark-list">
                         <li>
-                            <b>{{activeIncubatorsCount}} incubateurs depuis 2015</b>
+                            <strong>{{activeIncubatorsCount}} incubateurs depuis 2015</strong>
                             <div class="fr-text--sm">Grâce à son incubateur, chaque administration peut construire ses services numériques en suivant l'approche Startup d'État.</div>
                         </li>
                         <li>
-                            <b>Plus de 200 services numériques incubés</b>
+                            <strong>Plus de 200 services numériques incubés</strong>
                             <div class="fr-text--sm">Les incubateurs accompagnent les équipes en charge de ces services de la phase d’investigation jusqu’à leur pérennisation.</div>
                         </li>
                     </ul>
                     <h2 class="fr-h5">Des standards de qualité</h2>
                     <p class="fr-mb-0">Les services numériques construits dans le réseau beta.gouv.fr répondent à un haut niveau d'exigence :</p>
                     <ul class="checkmark-list">
-                        <li><b>Simplicité d'utilisation</b> par une conception proche des utilisateurices</li>
-                        <li><b>Accessibilité</b> et conception pour tous</li>
-                        <li><b>Protection des données personnelles</b></li>
-                        <li><b>Écoconception</b> et frugalité</li>
-                        <li><b>Transparence</b> via le code source et des statistiques ouverts</li>
-                        <li><b>Sécurité</b> agile</li>
-                        <li><b>Qualité logicielle</b> via code déployé et testé en continu</li>
-                        <li><b>Qualité du support</b></li>
+                        <li><strong>Simplicité d'utilisation</strong> par une conception proche des utilisateurices</li>
+                        <li><strong>Accessibilité</strong> et conception pour tous</li>
+                        <li><strong>Protection des données personnelles</strong></li>
+                        <li><strong>Écoconception</strong> et frugalité</li>
+                        <li><strong>Transparence</strong> via le code source et des statistiques ouverts</li>
+                        <li><strong>Sécurité</strong> agile</li>
+                        <li><strong>Qualité logicielle</strong> via code déployé et testé en continu</li>
+                        <li><strong>Qualité du support</strong></li>
                     </ul>
                 </div>
             </div>
             <div class="fr-grid-row fr-grid-row fr-mt-6w">
                 <div class="fr-col">
                     <h2 class="fr-mt-1w">Notre réseau</h2>
-                    <p><b>beta.gouv.fr fédère des incubateurs,</b> dans de nombreuses administrations. Chacun de ces incubateurs promeut l'approche beta.gouv.fr dans son administration et participe à sa transformation numérique.</p>
+                    <p><strong>beta.gouv.fr fédère des incubateurs,</strong> dans de nombreuses administrations. Chacun de ces incubateurs promeut l'approche beta.gouv.fr dans son administration et participe à sa transformation numérique.</p>
                 </div>
             </div>
         </div>
@@ -83,8 +83,8 @@ layout: default
                 <div class="fr-col-md-9">
                     <h2 style="color: var(--text-title-blue-france);">Vous souhaitez lancer un service numérique dans votre administration ?</h2>
                     <ol>
-                        <li>Lançons ensemble <b>votre premier produit</b></li>
-                        <li>Structurons <b>votre incubateur</b></li>
+                        <li>Lançons ensemble <strong>votre premier produit</strong></li>
+                        <li>Structurons <strong>votre incubateur</strong></li>
                         <li>Rejoignez le <span class="fr-text--bold">réseau beta.gouv.fr</span></li>
                     </ol>
                     <a class="fr-btn fr-btn--md fr-mt-3w" href="mailto:contact@beta.gouv.fr">Contactez-nous</a>

--- a/_layouts/incubateurs.html
+++ b/_layouts/incubateurs.html
@@ -34,32 +34,32 @@ layout: default
                 <div class="fr-col">
                     <ul class="checkmark-list">
                         <li>
-                            <span class="fr-text--bold">{{activeIncubatorsCount}} incubateurs depuis 2015</span>
+                            <b>{{activeIncubatorsCount}} incubateurs depuis 2015</b>
                             <div class="fr-text--sm">Grâce à son incubateur, chaque administration peut construire ses services numériques en suivant l'approche Startup d'État.</div>
                         </li>
                         <li>
-                            <span class="fr-text--bold">Plus de 200 services numériques incubés</span>
+                            <b>Plus de 200 services numériques incubés</b>
                             <div class="fr-text--sm">Les incubateurs accompagnent les équipes en charge de ces services de la phase d’investigation jusqu’à leur pérennisation.</div>
                         </li>
                     </ul>
                     <h2 class="fr-h5">Des standards de qualité</h2>
                     <p class="fr-mb-0">Les services numériques construits dans le réseau beta.gouv.fr répondent à un haut niveau d'exigence :</p>
                     <ul class="checkmark-list">
-                        <li><span class="fr-text--bold">Simplicité d'utilisation</span> par une conception proche des utilisateurices</li>
-                        <li><span class="fr-text--bold">Accessibilité</span> et conception pour tous</li>
-                        <li><span class="fr-text--bold">Protection des données personnelles</span></li>
-                        <li><span class="fr-text--bold">Écoconception</span> et frugalité</li>
-                        <li><span class="fr-text--bold">Transparence</span> via le code source et des statistiques ouverts</li>
-                        <li><span class="fr-text--bold">Sécurité</span> agile</li>
-                        <li><span class="fr-text--bold">Qualité logicielle</span> via code déployé et testé en continu</li>
-                        <li><span class="fr-text--bold">Qualité du support</span></li>
+                        <li><b>Simplicité d'utilisation</b> par une conception proche des utilisateurices</li>
+                        <li><b>Accessibilité</b> et conception pour tous</li>
+                        <li><b>Protection des données personnelles</b></li>
+                        <li><b>Écoconception</b> et frugalité</li>
+                        <li><b>Transparence</b> via le code source et des statistiques ouverts</li>
+                        <li><b>Sécurité</b> agile</li>
+                        <li><b>Qualité logicielle</b> via code déployé et testé en continu</li>
+                        <li><b>Qualité du support</b></li>
                     </ul>
                 </div>
             </div>
             <div class="fr-grid-row fr-grid-row fr-mt-6w">
                 <div class="fr-col">
                     <h2 class="fr-mt-1w">Notre réseau</h2>
-                    <p><span class="fr-text--bold">beta.gouv.fr fédère des incubateurs,</span> dans de nombreuses administrations. Chacun de ces incubateurs promeut l'approche beta.gouv.fr dans son administration et participe à sa transformation numérique.</p>
+                    <p><b>beta.gouv.fr fédère des incubateurs,</b> dans de nombreuses administrations. Chacun de ces incubateurs promeut l'approche beta.gouv.fr dans son administration et participe à sa transformation numérique.</p>
                 </div>
             </div>
         </div>
@@ -83,8 +83,8 @@ layout: default
                 <div class="fr-col-md-9">
                     <h2 style="color: var(--text-title-blue-france);">Vous souhaitez lancer un service numérique dans votre administration ?</h2>
                     <ol>
-                        <li>Lançons ensemble <span class="fr-text--bold">votre premier produit</span></li>
-                        <li>Structurons <span class="fr-text--bold">votre incubateur</span></li>
+                        <li>Lançons ensemble <b>votre premier produit</b></li>
+                        <li>Structurons <b>votre incubateur</b></li>
                         <li>Rejoignez le <span class="fr-text--bold">réseau beta.gouv.fr</span></li>
                     </ol>
                     <a class="fr-btn fr-btn--md fr-mt-3w" href="mailto:contact@beta.gouv.fr">Contactez-nous</a>

--- a/_pages/stats.md
+++ b/_pages/stats.md
@@ -152,8 +152,7 @@ Avant cela, le produit est encore trop instable dans son design global. La prior
 <p>
 Cet indicateur compte, par an, le nouveaux agents (intrapreneurs, équipes d'animation et de pilotage d'incubateurs, développeuses, développeurs, etc) impliqués dans le réseau beta.gouv.fr.
 </p>
-<p>
-Pour plus de détails sur la composition actuelle de la communauté beta.gouv.fr, <a href="https://beta.gouv.fr/communaute/">consultez cette page</a>.
+<p>La composition exacte est détaillée sur la page <a href="https://beta.gouv.fr/communaute/">communauté de beta.gouv.fr</a>.
 </p>
   </div>
   <div class="fr-grid-row fr-grid-row--gutters">

--- a/_pages/stats.md
+++ b/_pages/stats.md
@@ -147,7 +147,7 @@ Avant cela, le produit est encore trop instable dans son design global. La prior
   <br>
   <br>
   <div class="fr-col-md-8 fr-col-sm-12 fr-col-lg-8">
-    <h2>Nombre de nouveaux membres par année, et nombre d'agents publics formés à l'approche</h2>
+    <h2>Montée en compétence de l'administration</h2>
 <p>beta.gouv.fr souhaite faire <b>monter en compétences l'administration</b>, en formant des agents publics, par la pratique, à la construction de services publics numériques à impact et de qualité.</p>
 <p>
 Cet indicateur compte, par an, le nouveaux agents (intrapreneurs, équipes d'animation et de pilotage d'incubateurs, développeuses, développeurs, etc) impliqués dans le réseau beta.gouv.fr.

--- a/_pages/stats.md
+++ b/_pages/stats.md
@@ -38,6 +38,7 @@ additional_js:
         src="https://betagouv-animation-metabase.osc-secnum-fr1.scalingo.io/public/question/dc69430c-3929-4ca3-9d29-f6bb9f06c037"
         height="300"
         style="width: 100%; border: 0; background-color: transparent;"
+        title="Statistiques des produits à impact national"
       ></iframe>
     </div>
   </div>
@@ -56,6 +57,7 @@ additional_js:
       src="https://betagouv-animation-metabase.osc-secnum-fr1.scalingo.io/public/question/0e1d0920-fdd9-4d92-82cc-f8685cc063c5"
       height="300"
       style="width: 100%; border: 0; background-color: transparent;"
+        title="Statistiques des produits lancés chaque année"
       ></iframe>
     </div>
   </div>
@@ -85,6 +87,7 @@ additional_js:
             src="https://betagouv-animation-metabase.osc-secnum-fr1.scalingo.io/public/question/df66b4b5-da83-4131-90a5-52b7c68f10e0"
             height="300"
             style="width: 100%; border: 0; background-color: transparent;"
+            title="Statistiques d'ouverture du code source"
         ></iframe>
       </div>
       <div class="fr-col-md-6 fr-col-sm-12 fr-col-lg-6">
@@ -107,6 +110,7 @@ additional_js:
             src="https://betagouv-animation-metabase.osc-secnum-fr1.scalingo.io/public/question/4c8c5ab0-2ff1-4d81-abe2-115be0481e0a"
             height="300"
             style="width: 100%; border: 0; background-color: transparent;"
+            title="Statistiques de taux de publication de pages Statistiques"
         ></iframe>
       </div>
     </div>
@@ -117,6 +121,7 @@ additional_js:
             src="https://betagouv-animation-metabase.osc-secnum-fr1.scalingo.io/public/question/e5dbecb8-8601-4cfd-916b-faefff27eb60"
             height="300"
             style="width: 100%; border: 0; background-color: transparent;"
+            title="Statistiques de présence sur l'outil Dashlord"
         ></iframe>
       </div>
       <div class="fr-col-md-6 fr-col-sm-12 fr-col-lg-6">
@@ -135,6 +140,7 @@ Avant cela, le produit est encore trop instable dans son design global. La prior
             src="https://betagouv-animation-metabase.osc-secnum-fr1.scalingo.io/public/question/bde0b5e2-0e30-4df4-954d-a458b7b3f1db"
             height="300"
             style="width: 100%; border: 0; background-color: transparent;"
+            title="Statistiques de l'accessibilité numérique des produits"
         ></iframe>
       </div>
   </div>
@@ -156,6 +162,7 @@ Pour plus de détails sur la composition actuelle de la communauté beta.gouv.fr
             src="https://betagouv-animation-metabase.osc-secnum-fr1.scalingo.io/public/question/493930f1-f3d2-4df5-a5f8-a67d593addc5"
             height="300"
             style="width: 100%; border: 0; background-color: transparent;"
+            title="Statistiques sur les nouveaux membres, par année"
         ></iframe>
       </div>
   </div>
@@ -173,6 +180,7 @@ Pour plus de détails sur la composition actuelle de la communauté beta.gouv.fr
           src="https://betagouv-animation-metabase.osc-secnum-fr1.scalingo.io/public/question/3a9c4d96-43e6-4b82-b44d-6f99cd9ca604"
           height="400"
           style="width: 100%; border: 0; background-color: transparent;"
+          title="Statistiques sur les incubateurs du réseau, par année"
       ></iframe>
     </div>
  </div>
@@ -182,6 +190,7 @@ Pour plus de détails sur la composition actuelle de la communauté beta.gouv.fr
             src="https://betagouv-animation-metabase.osc-secnum-fr1.scalingo.io/public/question/bb37a864-df62-43b9-ae42-3a097da5ddae"
             height="300"
             style="width: 100%; border: 0; background-color: transparent;"
+            title="Statistiques sur les produits lancés en 2022 par incubateur"
         ></iframe>
       </div>
        <div class="fr-col-md-6 fr-col-sm-6 fr-col-lg-6">
@@ -189,6 +198,7 @@ Pour plus de détails sur la composition actuelle de la communauté beta.gouv.fr
              src="https://betagouv-animation-metabase.osc-secnum-fr1.scalingo.io/public/question/5709d2c1-7ad2-4a49-b6e3-bbf7558ce2c3"
              height="300"
              style="width: 100%; border: 0; background-color: transparent;"
+            title="Statistiques sur les produits lancés en 2023 par incubateur"
         ></iframe>
       </div>
   </div>


### PR DESCRIPTION
- Sur la page [Incubateurs](https://beta.gouv.fr/incubateurs/), certains textes emphasés devraient l'être sémantiquement
- Sur toutes les pages, les liens vers les réseaux sociaux n'avaient pas un beau nom (ex: linkedin-box au lieu de Linkedin)
- Sur la pages Statistiques, un lien n'était pas pertinents (“cette page”)
- Sur la page Statistiques, les frames n'avaient pas de titre