### PR TITLE
Corrige la génération du subject des emails

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -60,10 +60,11 @@ layout: default
           </p>
           <p>
             <span class="fr-icon-mail-line"></span>
+            {% assign subject = page.title | append: " sur beta.gouv.fr" %}
             {% if page.contact %}
-            <a class="fr-link" href="mailto:{{ page.contact }}?subject={{ page.title | url_encode }}%20sur%20beta.gouv.fr">Contacter l'équipe</a>.
+            <a class="fr-link" href="mailto:{{ page.contact }}?subject={{ subject | url_encode }}">Contacter l'équipe</a>.
             {% else %}
-            <a class="fr-link" href="mailto:{{ site.email }}?subject={{ page.title | url_encode }}%20sur%20beta.gouv.fr">Contacter l'incubateur</a>.</em>
+            <a class="fr-link" href="mailto:{{ site.email }}?subject={{ subject | url_encode }}">Contacter l'incubateur</a>.</em>
             {% endif %}
           </p>
           {% unless phase.status == 'investigation' or phase.status == 'transfer'  %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -60,11 +60,10 @@ layout: default
           </p>
           <p>
             <span class="fr-icon-mail-line"></span>
-            {% assign subject = page.title | append: " sur beta.gouv.fr" %}
             {% if page.contact %}
-            <a class="fr-link" href="mailto:{{ page.contact }}?subject={{ subject | url_encode }}">Contacter l'équipe</a>.
+            <a class="fr-link" href="mailto:{{ page.contact }}?subject={{ page.title | uri_escape }}%20sur%20beta.gouv.fr">Contacter l'équipe</a>.
             {% else %}
-            <a class="fr-link" href="mailto:{{ site.email }}?subject={{ subject | url_encode }}">Contacter l'incubateur</a>.</em>
+            <a class="fr-link" href="mailto:{{ site.email }}?subject={{ page.title | uri_escape }}%20sur%20beta.gouv.fr">Contacter l'incubateur</a>.</em>
             {% endif %}
           </p>
           {% unless phase.status == 'investigation' or phase.status == 'transfer'  %}


### PR DESCRIPTION
Sur la production

https://beta.gouv.fr/startups/l-application-du-cej.html
Le sujet de l'email est « L'application+du+CEJ sur beta.gouv.fr »

Sur la PR ça devrait être « L'application du CEJ sur beta.gouv.fr ».