### PR TITLE
Remove trailing slash for cartobio link

### DIFF
--- a/content/_startups/cartobio.md
+++ b/content/_startups/cartobio.md
@@ -12,7 +12,7 @@ phases:
   - name: acceleration
     start: 2023-05-01
 accessibility_status: non conforme
-link: https://cartobio.agencebio.org/
+link: https://cartobio.agencebio.org
 repository: https://github.com/AgenceBio/cartobio-front
 stats: true
 budget_url:


### PR DESCRIPTION
It breaks some assumptions about how to build some other urls.
