### PR TITLE
feat: timeline SE fix #18920

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -227,6 +227,23 @@ layout: default
         </div>
       </div>
     </div>
+    {% if page.phases %}
+    <h2>En quelques dates</h2>
+    <div class="startup-timeline">
+      {%- assign investigated=page.phases | where: 'name', 'investigation' | first %}
+      {%- assign constructed=page.phases | where: 'name', 'construction' | first %}
+      {%- assign accelerated=page.phases | where: 'name', 'acceleration' | first %}
+      {%- assign transfered=page.phases | where: 'name', 'transfer' | first %}
+      {%- assign succeeded=page.phases | where: 'name', 'success' | first %}
+      {%- assign finished=page.phases | where: 'name', 'alumni' | first %}
+      {% if investigated %}<div class="active"><b>Investigation</b><br/>{{ investigated.start | french_long_date }}</div>{% else %}<div><b>Investigation</b></div>{% endif %}
+      {% if constructed %}<div class="active"><b>Construction</b><br/>{{ constructed.start | french_long_date }}</div>{% elsif finished==nil %}<div><b>Construction</b></div>{% endif %}
+      {% if accelerated %}<div class="active"><b>Accélération</b><br/>{{ accelerated.start | french_long_date }}</div>{% elsif finished==nil %}<div><b>Accélération</b></div>{% endif %}
+      {% if transfered %}<div class="active"><b>Transfert</b><br/>{{ transfered.start | french_long_date }}</div>{% elsif succeeded==nil and  finished==nil %}<div><b>Transfert</b></div>{% endif %}
+      {% if succeeded %}<div class="success"><b>Pérénnisé</b><br/>{{ succeeded.start | french_long_date }}</div>{% elsif finished==nil %}<div><b>Pérénnisé</b></div>{% endif %}
+      {% if finished %}<div class="finished"><b>Partenariat terminé</b><br/>{{ finished.start | french_long_date }}</div>{% endif %}
+    </div>
+    {% endif %}
   </div>
 </div>
 

--- a/_plugins/dates.rb
+++ b/_plugins/dates.rb
@@ -1,0 +1,16 @@
+module Jekyll
+    module DateFilter
+        MONTHS_FR = %w(Janvier Février Mars Avril Mai Juin Juillet Aout Septembre Octobre Novembre Décembre)
+
+        def french_long_date(input)
+            day = time(input).strftime("%-d") # no leading zero
+            if day == "1"; day="1er"; end
+            month = time(input).strftime("%m")
+            year = time(input).strftime("%Y")
+            day+' '+ MONTHS_FR[month.to_i - 1]+' '+year
+        end
+
+    end
+end
+
+Liquid::Template.register_filter(Jekyll::DateFilter)

--- a/assets/main.css
+++ b/assets/main.css
@@ -551,3 +551,37 @@ mark {
 #job-page h3 {
   margin: 3rem 0 1rem 0;
 }
+
+.startup-timeline {
+  display: flex;
+  margin: 30px 0;
+}
+
+.startup-timeline > div {
+  border-top: 0.5rem solid var(--background-contrast-grey);
+  flex: 1 0 auto;
+  margin: 3px;
+  padding: 5px;
+}
+
+@media screen and (max-width: 768px) {
+  .startup-timeline {
+    display: block;
+  }
+  .startup-timeline > div {
+    width: 200px;
+    margin-bottom: 2rem;
+  }
+}
+
+.startup-timeline > div.active {
+  border-color: var(--background-action-low-blue-france);
+}
+
+.startup-timeline > div.success {
+  border-color: var(--background-action-low-green-emeraude);
+}
+
+.startup-timeline > div.finished {
+  border-color: var(--background-action-low-red-marianne);
+}


### PR DESCRIPTION
Version initiale pour https://github.com/betagouv/beta.gouv.fr/issues/18920

 
 - Si "succès", et pas "transfert" la phase "transfert" n'est pas affichée
 - Si "alumni", les étapes intermédiaires non datées ne sont pas affichées

ex:

<img width="1158" alt="Capture d’écran 2024-03-29 à 09 05 32" src="https://github.com/betagouv/beta.gouv.fr/assets/124937/09caaae5-e85b-4252-84be-503ccbb4f06d">
