### PR TITLE
Ajoute la recherche sur mobile

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -69,11 +69,11 @@
     <div class="fr-container">
       <button class="fr-link--close fr-link" aria-controls="modal-menu-mobile">Fermer</button>
       <div class="fr-header__menu-links"></div>
-      <nav class="fr-nav" id="navigation-832" role="navigation" aria-label="Menu principal">
+      <nav class="fr-nav" id="navigation" role="navigation" aria-label="Menu principal">
           <ul class="fr-nav__list">
                   <li class="fr-nav__item">
-                    <button class="fr-nav__btn" aria-expanded="false" aria-controls="menu-776" {% if page.url contains 'approche' %}aria-current="true"{% endif %}>Programme</button>
-                    <div class="fr-collapse fr-menu" id="menu-776">
+                    <button class="fr-nav__btn" aria-expanded="false" aria-controls="menu-program" {% if page.url contains 'approche' %}aria-current="true"{% endif %}>Programme</button>
+                    <div class="fr-collapse fr-menu" id="menu-program">
                         <ul class="fr-menu__list">
                             <li>
                                 <a class="fr-nav__link" href="/approche" target="_self">Découvrir le programme</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,10 @@
             </div>
 
             <div class="fr-header__navbar">
-              <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-833" aria-haspopup="menu" title="Menu" id="fr-btn-menu-mobile">
+              <button class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="header-search" id="fr-btn-search-mobile" title="Rechercher">
+                  Rechercher
+              </button>
+              <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-menu-mobile" aria-haspopup="menu" title="Menu" id="fr-btn-menu-mobile">
                   Menu
               </button>
             </div>
@@ -27,21 +30,24 @@
 
         <div class="fr-header__tools">
           <div class="fr-header__tools-links">
-            <ul class="fr-links-group">
+            <ul class="fr-btns-group">
               {% for item in site.data.menu.shortcuts %}
               <li class="fr-shortcuts__item">
                 {% if item.external == true %}
-                  <a class="fr-link" href="{{ item.url }}" title="{{ item.label }} - nouvelle fenêtre" target="_blank" rel="noopener">{{ item.label }}</a>
+                  <a class="fr-btn" href="{{ item.url }}" title="{{ item.label }} - nouvelle fenêtre" target="_blank" rel="noopener">{{ item.label }}</a>
                 {% else %}
-                  <a class="fr-link" href="{{ item.url }}">{{ item.label }}</a>
+                  <a class="fr-btn--{{ item.icon }} fr-btn" href="{{ item.url }}">{{ item.label }}</a>
                 {% endif %}
               </li>
               {% endfor %}
             </ul>
           </div>
 
-          <div class="fr-header__search fr-modal" id="header-search" data-fr-js-modal="true" data-fr-js-header-modal="true">
+          <div class="fr-header__search fr-modal" id="header-search" data-fr-js-modal="true" data-fr-js-header-modal="true" aria-labelledby="button-header-search">
             <div class="fr-container fr-container-lg--fluid">
+              <button class="fr-btn--close fr-btn" aria-controls="header-search" id="button-header-search" title="Fermer">
+                Fermer
+              </button>
               <form id="header-search-main" method="get" action="/recherche" role="search" class="fr-search-bar">
                 <label class="fr-label" for="search">
                     Recherche
@@ -59,9 +65,9 @@
   </div>
 
   <!-- Navigation principale -->
-  <div class="fr-header__menu fr-modal" id="modal-833" aria-labelledby="fr-btn-menu-mobile">
+  <div class="fr-header__menu fr-modal" id="modal-menu-mobile" aria-labelledby="fr-btn-menu-mobile">
     <div class="fr-container">
-      <button class="fr-link--close fr-link" aria-controls="modal-833">Fermer</button>
+      <button class="fr-link--close fr-link" aria-controls="modal-menu-mobile">Fermer</button>
       <div class="fr-header__menu-links"></div>
       <nav class="fr-nav" id="navigation-832" role="navigation" aria-label="Menu principal">
           <ul class="fr-nav__list">


### PR DESCRIPTION
Horreur ! Ce midi, j'ai voulu rechercher une SE et j'ai réalisé avec stupéfaction que la recherche n'était pas disponible sur mobile : 

<img width="375" alt="Screenshot du header sur mobile" src="https://github.com/betagouv/beta.gouv.fr/assets/1374389/1f626727-8b4d-4e6c-9673-b1e8ccc47007">

En plus de ça, il y avait un petit glitch graphique sur les liens Communauté/Documentation (ils sont tout tassés) : 
<img width="371" alt="Screeenshot de la modale menu ouverte sur mobile" src="https://github.com/betagouv/beta.gouv.fr/assets/1374389/7250ecbc-4f1a-4391-8076-68cf0bc2f8f5">


### Correction

On a bien accès à la recherche
<img width="444" alt="Screenshot de la proposition de menu sur mobile" src="https://github.com/betagouv/beta.gouv.fr/assets/1374389/1308e4ea-eccc-43f8-a695-36edec2ae11f">
<img width="444" alt="Screenshot de la proposition de modale de recherche ouverte sur mobile" src="https://github.com/betagouv/beta.gouv.fr/assets/1374389/78077074-5a3b-4ece-b524-22fff77e0eef">

Et en plus, le glitch graphique est corrigé : 
<img width="439" alt="Screentshot de la proposition de modale de menu ouverte sur mobile" src="https://github.com/betagouv/beta.gouv.fr/assets/1374389/4b8bb7d3-f309-40d4-947b-b3b5ead14be7">

Au passage, j'ai corrigé quelques attributs aria qui n'allaient pas.