### PR TITLE
[Sirius] Mise à jour de l'URL

### DIFF
--- a/content/_startups/sirius.md
+++ b/content/_startups/sirius.md
@@ -15,8 +15,8 @@ usertypes:
   - particulier
   - etablissement-scolaire
 accessibility_status: partiellement conforme
-link: https://sirius.apprentissage.beta.gouv.fr
-stats_url: https://sirius.apprentissage.beta.gouv.fr/statistiques
+link: https://sirius.inserjeunes.beta.gouv.fr
+stats_url: https://sirius.inserjeunes.beta.gouv.fr/statistiques
 stats: true
 dashlord_url: https://dashlord.incubateur.net/url/sirius-apprentissage-beta-gouv-fr/
 thematiques:

--- a/content/_startups/sirius.md
+++ b/content/_startups/sirius.md
@@ -18,7 +18,7 @@ accessibility_status: partiellement conforme
 link: https://sirius.inserjeunes.beta.gouv.fr
 stats_url: https://sirius.inserjeunes.beta.gouv.fr/statistiques
 stats: true
-dashlord_url: https://dashlord.incubateur.net/url/sirius-apprentissage-beta-gouv-fr/
+dashlord_url: https://dashlord.incubateur.net/startup/sirius
 thematiques:
   - Jeunesse
   - Formation


### PR DESCRIPTION
L'URL du produit Sirius à changé de [sirius.apprentissage.beta.gouv.fr](sirius.apprentissage.beta.gouv.fr) à [sirius.inserjeunes.beta.gouv.fr](sirius.inserjeunes.beta.gouv.fr).