### PR TITLE
fix(api): always show stats_url

### DIFF
--- a/api/v2.6/startups.json
+++ b/api/v2.6/startups.json
@@ -11,7 +11,7 @@ layout: null
         , "type"      : "startup"
         , "attributes":
             { "name"  : "{{ startup.title }}"
-            , "pitch" : "{{ startup.mission }}"{% if startup.stats %}
+            , "pitch" : "{{ startup.mission }}"
             , "stats_url": "{% if startup.stats_url %}{{ startup.stats_url }}{% else %}{{ startup.link | strip }}/stats{% endif %}"{% endif %}
             {% if startup.budget_url %}
             ,"budget_url": "{{ startup.budget_url }}"{% endif %}{% if startup.link %}

--- a/api/v2.6/startups.json
+++ b/api/v2.6/startups.json
@@ -12,7 +12,7 @@ layout: null
         , "attributes":
             { "name"  : "{{ startup.title }}"
             , "pitch" : "{{ startup.mission }}"
-            , "stats_url": "{% if startup.stats_url %}{{ startup.stats_url }}{% else %}{{ startup.link | strip }}/stats{% endif %}"
+            , "stats_url": "{% if startup.stats_url %}{{ startup.stats_url }}{% else %}{% if startup.stats %}{{ startup.link | strip }}/stats{% endif %}{% endif %}"
             {% if startup.budget_url %}
             ,"budget_url": "{{ startup.budget_url }}"{% endif %}{% if startup.link %}
             , "link": "{{ startup.link}}"{% endif %}{% if startup.repository %}

--- a/api/v2.6/startups.json
+++ b/api/v2.6/startups.json
@@ -12,7 +12,7 @@ layout: null
         , "attributes":
             { "name"  : "{{ startup.title }}"
             , "pitch" : "{{ startup.mission }}"
-            , "stats_url": "{% if startup.stats_url %}{{ startup.stats_url }}{% else %}{{ startup.link | strip }}/stats{% endif %}"{% endif %}
+            , "stats_url": "{% if startup.stats_url %}{{ startup.stats_url }}{% else %}{{ startup.link | strip }}/stats{% endif %}"
             {% if startup.budget_url %}
             ,"budget_url": "{{ startup.budget_url }}"{% endif %}{% if startup.link %}
             , "link": "{{ startup.link}}"{% endif %}{% if startup.repository %}


### PR DESCRIPTION
actuellement si `stats` n'est pas renseigné mais `stats_url` l'est, l'url ne s'affiche pas dans l'API