### PR TITLE
Fix typo dans le `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 # See more at http://EditorConfig.org
 
-root = true # this is the topmost editorconfig file
+# This is the topmost editorconfig file.
+root = true
 
 [**/*]
 charset = utf-8


### PR DESCRIPTION
Les commentaires devraient être sur une ligne séparée.

[Comments should go on their own lines.](https://editorconfig.org/#file-format-details)