### PR TITLE
Correctifs accessibilité, la suite

### DIFF
--- a/_includes/card-community.html
+++ b/_includes/card-community.html
@@ -43,9 +43,12 @@
           {%- endif -%}
 
           {%- unless include.hide_details -%}
+            {% assign author_content = author.content | strip_newlines | size %}
+            {% if author_content > 0 %}
             <p class="fr-card__desc">
               {{ author.content | strip_html }}
             </p>
+            {%- endif -%}
 
             {% assign previously = author.previously | default: empty_array %}
             {% assign all_startups = startups | concat: previously | compact | uniq %}

--- a/_includes/card-incubator.html
+++ b/_includes/card-incubator.html
@@ -11,7 +11,10 @@
         <p class="fr-card__detail fr-mt-1w">{{ owner.name }}</p>
         {% endif %}
         <!-- We use HTML for bold text into short descriptions (easier for now instead of parsing every field with https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx-frontmatter/) -->
+        {% assign short_description = incubator.short_description | strip_newlines | size %}
+        {% if short_description > 0 %}
         <p class="fr-card__desc">{{ incubator.short_description }}</p>
+        {% endif %}
     </div>
     <div class="fr-card__img">
         <img

--- a/_includes/hero-startup.html
+++ b/_includes/hero-startup.html
@@ -5,22 +5,22 @@
 <div class="hero__startup fr-container-fluid fr-py-6w">
   <div class="fr-container">
     <div class="fr-grid-row fr-grid-row--gutters">
-      <div class="{% if screenshot_file %}fr-col-lg-6{% endif %}">
+      <div class="hero__startup-text {% if screenshot_file %}fr-col-lg-6{% endif %}">          
+        <h1>{{ include.startup.title | escape }}</h1>
 
         {% if include.startup.events.last.name == "national_impact" %}
         <span class="fr-badge fr-badge--success">Service à impact national</span>
         {% elsif include.startup.fast %}
         <span class="fr-badge fr-badge--new">Lauréat FAST</span>
         {% endif %}
-          
-        <h1>{{ include.startup.title | escape }}</h1>
+
         {% if include.startup.mission %}
           <p class="hero__startup__mission fr-mt-3w fr-h3">
             {{ include.startup.mission | escape }}
           </p>
         {% endif %}
         {% if include.startup.link.size > 0 %}
-          <a href="{{ include.startup.link }}" title="{{ include.startup.link | remove:'www.' | split: '//' | last | split: '/'' | first }} - nouvelle fenêtre" class="fr-link" target="_blank">{{ include.startup.link | remove:'www.' | split: "//" | last | split: "/" | first }}</a>
+        <p><a href="{{ include.startup.link }}" title="{{ include.startup.link | remove:'www.' | split: '//' | last | split: '/'' | first }} - nouvelle fenêtre" class="fr-link" target="_blank">{{ include.startup.link | remove:'www.' | split: "//" | last | split: "/" | first }}</a></p>
         {% endif %}
         <p class="fr-mt-3w">
             <a class="fr-tag" href="{{ phase.documentation_url }}">Produit {% if phase.id != '/phases/success' %}en{% endif %} {{ phase.label | downcase }}</a>

--- a/_layouts/communaute.html
+++ b/_layouts/communaute.html
@@ -17,11 +17,20 @@ layout: default
                 <div class="chart-wrapper">
                     <canvas id="member"> Nous avons actuellement {{ currents | size }} membres. </canvas>
                 </div>
+                {%- capture alt -%}
+                Ce graphique montre la courbe d'évolution de nos effectifs depuis 2013. Nos effectifs montent continuellement (nous avons passé la barre des 1000 membres en 2022, et celle des 1500 membres début 2024).
+                La part d'agents publics, d'indépendants et de prestataires reste relativement équivalente avec le temps.
+                {%- endcapture -%}
+                {% include transcription.html id="member-alt" title="Progression des effectifs" alt=alt %}
             </div>
             <div class="fr-col-12 fr-col-md-6">
                 <div class="chart-wrapper">
                     <canvas id="pie-chart" aria-label="Graphique de répartition des membres par compétences" role="img"></canvas>
                 </div>
+                {%- capture alt -%}
+                Ce graphique en forme de camembert montre la répartition par rôle dans la communauté. Le métier le plus représenté est le développement (environ 35 % de la communauté).
+                {%- endcapture -%}
+                {% include transcription.html id="pie-chart-alt" title="Répartition des membres par compétences" alt=alt %}
             </div>
        </div>
        <div class="fr-grid-row fr-grid-row--gutters">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -185,25 +185,22 @@ layout: default
     <div class="centered">
       <h2 class="section-title">Un programme :<br> <strong class="section-description">3 principes</strong></h2>
     </div>
-    <div class="fr-grid-row fr-grid-row--center fr-grid-row--gutters startups">
+    <div class="fr-grid-row fr-grid-row--center fr-grid-row--gutters">
       <div class="fr-col-12 fr-col-md-4">
         <img src="/assets/home/manifest.svg" class="section-principle-animation" alt="">
       </div>
-      <div class="fr-py-6w fr-col-12 fr-col-md-8">
-        <p class="section-principle-list-item">
-          <span class="bigger-font">1.</span>
+      <ul class="fr-py-6w fr-col-12 fr-col-md-8">
+        <li class="section-principle-list-item">
           <span class="section-principle-list-item-content">Les besoins des <b>utilisatrices et utilisateurs</b> sont toujours prioritaires.</span>
-        </p>
-        <p class="section-principle-list-item">
-          <span class="bigger-font">2.</span>
+        </li>
+        <li class="section-principle-list-item">
           <span class="section-principle-list-item-content">Nous travaillons sans préjuger du résultat final. Seul l'<b>impact compte</b></span>.
-        </p>
-        <p class="section-principle-list-item">
-          <span class="bigger-font">3.</span>
+        </li>
+        <li class="section-principle-list-item">
           <span class="section-principle-list-item-content">Nous faisons <b>confiance aux agents publics</b>, qui connaissent le terrain</span>.
-        </p>
-        <a class="fr-btn fr-btn--md fr-btn--secondary fr-enlarge-link" href="/manifeste">Lire notre manifeste</a>
-      </div>
+        </li>
+      </ul>
+      <p><a class="fr-btn fr-btn--md fr-btn--secondary fr-enlarge-link" href="/manifeste">Lire notre manifeste</a></p>
     </div>
   </div>
 </section>

--- a/_layouts/recherche.html
+++ b/_layouts/recherche.html
@@ -157,9 +157,9 @@ layout: default
                         <div class="fr-card fr-enlarge-link fr-card--sm">
                             <div class="fr-card__body">
                                 <div class="fr-card__content">
-                                    <h3 class="fr-card__title">
+                                    <p class="fr-card__title">
                                         <a href="${incubator.url}">${incubator.title}</a>
-                                    </h3>
+                                    </p>
                                 </div>
                             </div>
                         </div>
@@ -230,9 +230,9 @@ layout: default
                         <div class="fr-tile fr-enlarge-link">
                             <div class="fr-tile__body">
                                 <div class="fr-tile__content">
-                                    <h3 class="fr-tile__title">
+                                    <p class="fr-tile__title">
                                         <a href="${page.url}">${page.title}</a>
-                                    </h3>
+                                    </p>
                                 </div>
                             </div>
                         </div>

--- a/_layouts/recherche.html
+++ b/_layouts/recherche.html
@@ -15,19 +15,19 @@ layout: default
     </ul>
   </div>
 
-  <div id="search-results-incubators">
+  <div id="search-results-incubators" class="search-results">
     <h2 class="fr-h3 fr-pt-4w" id="search-results-incubators-title">Incubateurs</h2>
-    <div id="search-results-incubators-list" class="fr-grid-row fr-grid-row--gutters"></div>
+    <ul role="list" id="search-results-incubators-list" class="fr-grid-row fr-grid-row--gutters"></ul>
   </div>
 
-  <div id="search-results-realisations">
+  <div id="search-results-realisations" class="search-results">
     <h2 class="fr-h3 fr-pt-4w" id="search-results-realisations-title">Services numériques</h2>
-    <div id="search-results-realisations-list" class="fr-grid-row fr-grid-row--gutters"></div>
+    <ul role="list" id="search-results-realisations-list" class="fr-grid-row fr-grid-row--gutters"></ul>
   </div>
 
-  <div id="search-results-pages">
+  <div id="search-results-pages" class="search-results">
     <h2 class="fr-h3 fr-pt-4w" id="search-results-pages-title">Pages</h2>
-    <div id="search-results-pages-list" class="fr-grid-row fr-grid-row--gutters"></div>
+    <ul role="list" id="search-results-pages-list" class="fr-grid-row fr-grid-row--gutters"></ul>
   </div>
 </div>
 
@@ -153,7 +153,7 @@ layout: default
           searchResultTitleId: 'search-results-incubators-title',
           searchResultListId: 'search-results-incubators-list',
           print: function(incubator) {
-             return `<div class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">
+             return `<li class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">
                         <div class="fr-card fr-enlarge-link fr-card--sm">
                             <div class="fr-card__body">
                                 <div class="fr-card__content">
@@ -163,7 +163,7 @@ layout: default
                                 </div>
                             </div>
                         </div>
-                    </div>`;
+                    </li>`;
           },
           // https://www.fusejs.io/api/options.html
           idx: new Fuse(incubatorsData, {
@@ -190,7 +190,7 @@ layout: default
           searchResultTitleId: 'search-results-realisations-title',
           searchResultListId: 'search-results-realisations-list',
           print: function(startup) {
-             return `<div class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">
+             return `<li class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">
                         <div class="fr-card fr-enlarge-link fr-card--sm">
                             <div class="fr-card__body">
                                 <div class="fr-card__content">
@@ -201,7 +201,7 @@ layout: default
                                 </div>
                             </div>
                         </div>
-                    </div>`;
+                    </li>`;
           },
           // https://www.fusejs.io/api/options.html
           idx: new Fuse(startupsData, {
@@ -226,7 +226,7 @@ layout: default
           searchResultTitleId: 'search-results-pages-title',
           searchResultListId: 'search-results-pages-list',
           print: function(page) {
-             return `<div class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">
+             return `<li class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">
                         <div class="fr-tile fr-enlarge-link">
                             <div class="fr-tile__body">
                                 <div class="fr-tile__content">
@@ -236,7 +236,7 @@ layout: default
                                 </div>
                             </div>
                         </div>
-                    </div>`;
+                    </li>`;
           },
           // https://www.fusejs.io/api/options.html
           idx: new Fuse(pagesData, {

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -43,7 +43,8 @@ layout: default
       </div>
       <div class="fr-col-md-4">
         <!-- INFO -->
-        <div class="fr-py-4w fr-px-4w fr-mt-3w" style="border: 1px solid var(--light-border-default-grey, #E5E5E5);">
+        <div id="about" class="fr-py-4w fr-px-4w fr-mt-3w">
+          <h2>À propos</h2>
           <p>
             {% if phase.status == 'success' %}
               <b>{{ page.title }}</b> a été portée par <a href="/incubateurs/{{ page.incubator }}" title="{{ incubator.title }}">{{ incubator.title }}</a>.

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -144,6 +144,7 @@ layout: default
               {% capture link_bonnes_pratiques %}
               <li>
                 <a class="fr-link fr-icon-info-line fr-link--icon-left"
+                  role="link"
                   {% if page.dashlord_url %}href="{{page.dashlord_url }}"{% endif %}
                   aria-disabled="{% if page.dashlord_url %}false{% else %}true{% endif %}"
                   >Suivi des bonnes pratiques

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -76,7 +76,7 @@ layout: default
                   Code source
                 </a>
                 {% else %}
-                <a class="fr-link fr-link--icon-left fr-icon-github-fill" aria-disabled="true" >
+                <a class="fr-link fr-link--icon-left fr-icon-github-fill" role="link" aria-disabled="true" >
                   Code source (non disponible)
                 </a>
                 {% endif %}
@@ -94,7 +94,7 @@ layout: default
                   Budget
                 </a>
                 {% else %}
-                <a class="fr-link fr-icon-money-euro-circle-line fr-link--icon-left" aria-disabled="true" >
+                <a class="fr-link fr-icon-money-euro-circle-line fr-link--icon-left" role="link" aria-disabled="true" >
                   Budget (non disponible)
                 </a>
               </li>
@@ -112,7 +112,7 @@ layout: default
                   Statistiques d'usage
                 </a>
                 {% else %}
-                <a class="fr-link fr-link--icon-left fr-icon-line-chart-line" aria-disabled="true">
+                <a class="fr-link fr-link--icon-left fr-icon-line-chart-line" role="link" aria-disabled="true">
                   Statistiques d'usage (non disponible)
                 </a>
                 {% endif %}
@@ -127,6 +127,7 @@ layout: default
               <li>
                 <a class="fr-link fr-icon-warning-line fr-link--icon-left"
                   {% if page.analyse_risques_url %}href="{{page.analyse_risques_url }}"{% endif %}
+                  role="link" 
                   aria-disabled="{% if page.analyse_risques_url %}false{% else %}true{% endif %}"
                 >
                 Analyse de risque

--- a/_pages/accessibilite.md
+++ b/_pages/accessibilite.md
@@ -30,14 +30,10 @@ L’audit de conformité au RGAA version 4.2 réalisé en août 2024 par la soci
 
 #### Non-conformités
 
-Voici les non-conformités relevées par l'audit : 
-- La page [Communauté](/communaute/) affiche des graphiques sans alternatives textuelles (critère 4.8).
+Voici les non-conformités relevées par l'audit, n'ayant pas encore été corrigées : 
 - Notre [bilan 2023](https://beta.gouv.fr/content/docs/betagouv_presentation.pdf) sous forme de PDF ne possède pas de version accessible (critère 13.3).
 - Nos fiches produits, rédigées par des contributeurs, ne sont pas toujours correctement structurées par des titres (critère 9.1)
-- Certains contrastes entre couleur de texte et couleur d’arrière-plan ne sont pas suffisamment élevés (critère 3.2).
-- Certaines balises sont utilisées uniquement à des fins de présentation (critère 8.9).
 - Certaines listes ne sont pas correctement structurées (critère 9.3).
-- Des informations ne sont pas compréhensibles lorsque les feuilles de styles sont désactivées (critère 10.3).
 - Des déclarations CSS de couleurs de fond et de police ne sont pas correctement utilisées (critère 10.5).
 
 Nous souhaitons les corriger courant 2024.

--- a/assets/main.css
+++ b/assets/main.css
@@ -70,6 +70,10 @@ main .fr-container img {
   color: #4941c0;
 }
 
+#about {
+  border: 1px solid var(--light-border-default-grey, #E5E5E5);
+}
+
 /* Couleurs de sections et espacemements */
 .section-grey {
   background-color: #e9e6fc;

--- a/assets/main.css
+++ b/assets/main.css
@@ -387,8 +387,14 @@ ul li p {
   text-align: center;
 }
 
+.section-principle ul { list-style-type: numeric; }
+.section-principle ::marker { 
+  font-weight: bold;
+  font-size: 3.5em;
+}
 .section-principle-list-item {
   margin-bottom: 3em;
+  margin-left: 3em;
 }
 
 .section-principle-animation {

--- a/assets/main.css
+++ b/assets/main.css
@@ -501,6 +501,10 @@ mark {
   margin-bottom: 3rem;
 }
 
+.search-results ul {
+  list-style-type: none;
+}
+
 #realisations .hero-section img {
   max-height: 12.5rem;
   object-fit: contain;

--- a/assets/main.css
+++ b/assets/main.css
@@ -106,6 +106,11 @@ main .fr-container img {
  Ci-dessous, modifications temporaire au système de design
 */
 
+/* Rendre les abbr accessible */
+.fr-card abbr {
+  z-index: 2;
+}
+
 /* Afficher le curseur même quand on est sur la page active */
 .fr-nav__item--active > .fr-nav__link {
   pointer-events: all !important;

--- a/assets/main.css
+++ b/assets/main.css
@@ -304,7 +304,8 @@ ul li p {
 
 /* START SECTION CLASS */
 .section-blue {
-  background: linear-gradient(270.3deg, rgba(123, 97, 255, 0.46) 3.25%, rgba(123, 97, 255, 0.63) 55.33%, rgba(123, 97, 255, 0.39) 99.82%), linear-gradient(0deg, #00006d, #00006d);
+  background-image: linear-gradient(270.3deg, rgba(123, 97, 255, 0.46) 3.25%, rgba(123, 97, 255, 0.63) 55.33%, rgba(123, 97, 255, 0.39) 99.82%), linear-gradient(0deg, #00006d, #00006d);
+  background-color: #4941C0;
 }
 
 .section-white h2 {

--- a/assets/main.css
+++ b/assets/main.css
@@ -66,9 +66,17 @@ main .fr-container img {
   width: 100%;
 }
 
+/* Hero header */
 .hero__startup__mission {
   color: #4941c0;
 }
+/* Move badges before heading */
+.hero__startup-text {
+  display: flex;
+  flex-direction: column;
+}
+.hero__startup-text > * { order: 1; }
+.hero__startup-text > .fr-badge { order: 0; }
 
 #about {
   border: 1px solid var(--light-border-default-grey, #E5E5E5);


### PR DESCRIPTION
Côté sémantique
- 🐛 Ajout d'un rôle link sur les liens désactivés, pour les rendre visibles des lecteurs d'écrans
- 🧹 Suppression des balises hX quand il n'y a pas de contenu associé (dans une carte simple par exemple)
- 🧹 Suppression des balises p vide 
- ✨ Usage des balises ul/li pour... une liste !

Côté CSS
- 🐛 Rendre nos abbréviations accessibles à la souris (pour que les sigles DGCCRF, MENJS ou DGEFP n'aient plus de secret pour personne)
- 🎨 Spécification d'une couleur de fond quand une couleur de texte est configurée (pour éviter les problèmes de contrastes quand une personne surcharge le style)

Côté expérience utilisateur
- 🖌️ Ajout d'un sous-titre dans la sidebar d'une fiche produit pour faciliter la hiérarchie de l'information aux personnes naviguant sans CSS
- 🔄 Changement d'ordre de certaines balises pour donner plus de contexte aux lecteurs d'écran
- ✍️ Nouvelle description pour les graphiques de la page communauté