### PR TITLE
Fix: Add title to page

### DIFF
--- a/_includes/card-startup.html
+++ b/_includes/card-startup.html
@@ -12,7 +12,7 @@
             <p class="fr-card__detail">
                 {%- for sponsorId in startup.sponsors -%}
                     {% assign sponsor = site.organisations | where: 'id', sponsorId | first %}
-                    {% if forloop.index > 1 %} / {% endif %}<abbr title="{{sponsor.name}}">{{sponsor.acronym}}</abbr>
+                    {% if forloop.index > 1 %} / {% endif %}<abbr title="{{sponsor.acronym}} - {{sponsor.name}}">{{sponsor.acronym}}</abbr>
                 {%- endfor -%}
             </p>
         {%- endif -%}

--- a/_pages/en/home.md
+++ b/_pages/en/home.md
@@ -2,4 +2,5 @@
 layout: en/home
 summary: We build digital public services
 permalink: /en/
+title: Home
 ---


### PR DESCRIPTION
La page https://beta.gouv.fr/en/ n'a pas de titre, c'est maintenant corrigé