### PR TITLE
Suppression des membres inactifs de la startup Espace sur Demande

### DIFF
--- a/content/_authors/alexandre.joubert.md
+++ b/content/_authors/alexandre.joubert.md
@@ -10,7 +10,6 @@ missions:
     employer: ANCT
     startups:
       - agents.en.intervention
-      - espace.sur.demande
   - start: 2024-09-10
     end: 2025-03-31
     status: independent

--- a/content/_authors/florent.lienard.md
+++ b/content/_authors/florent.lienard.md
@@ -9,7 +9,6 @@ missions:
     employer: Dinum
     startups:
       - agents.en.intervention
-      - espace.sur.demande
 memberType: beta
 ---
 UX/UI Designer

--- a/content/_authors/sylvain.le.gleau.md
+++ b/content/_authors/sylvain.le.gleau.md
@@ -11,7 +11,6 @@ missions:
     employer: Scopyleft
     startups:
       - agents.en.intervention
-      - espace.sur.demande
 memberType: beta
 previously:
   - mon.espace.collectivite


### PR DESCRIPTION
Suppression des membres inactifs de l’équipe Espace sur Demande à la demande de l’intra : https://gitlab.com/incubateur-territoires/startups/espace-sur-demande/application/-/issues/678
@xavren 