### PR TITLE
Afficher uniquement les incubateurs actifs

### DIFF
--- a/_layouts/communaute.html
+++ b/_layouts/communaute.html
@@ -58,7 +58,7 @@ layout: default
             <div class="fr-col fr-col-12 fr-col-md-3 beta-list-item">
                 <p>
                     <span class="beta-square-list-item">■</span>
-                    <b>{{site.incubators | filter_incubators_with_active_startups: site.startups | size }} incubateurs</b><br>
+                    <b>{{ site.incubators | filter_incubators_with_active_startups: site.startups | size }} incubateurs</b><br>
                     au sein d'agences déconcentrées, d'opérateurs et de ministères.
                     <a
                         href="/incubateurs"

--- a/_layouts/communaute.html
+++ b/_layouts/communaute.html
@@ -58,7 +58,7 @@ layout: default
             <div class="fr-col fr-col-12 fr-col-md-3 beta-list-item">
                 <p>
                     <span class="beta-square-list-item">■</span>
-                    <b>{{ site.incubators.size }} incubateurs</b><br>
+                    <b>{{site.incubators | filter_incubators_with_active_startups: site.startups | size }} incubateurs</b><br>
                     au sein d'agences déconcentrées, d'opérateurs et de ministères.
                     <a
                         href="/incubateurs"


### PR DESCRIPTION
@fannyblanc et son oeil de lynx ont remarqué une différence entre le nombre d'incubateurs affichés sur : 
- la page [Incubateurs](https://beta.gouv.fr/incubateurs/) 
- la page [Communauté](https://beta.gouv.fr/communaute/) 

J'ai mis le même filtre aux 2 endroits (uniquement les actifs)