### PR TITLE
Conforme is actually 'totalement conforme'

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -165,7 +165,7 @@ layout: default
               {% capture accessibilite_indicator %}
                 {% if page.accessibility_status %}
                   <li>
-                      <span class="fr-badge fr-text--xs {% if page.accessibility_status == 'conforme' %}fr-badge--success{% endif %}">Accessibilité : {{ page.accessibility_status }}</span>
+                      <span class="fr-badge fr-text--xs {% if page.accessibility_status == 'totalement conforme' %}fr-badge--success{% endif %}">Accessibilité : {{ page.accessibility_status }}</span>
                       {% if page.accessibility_status == 'non conforme' %}
                         <button id="button-non-conforme" aria-describedby="tooltip-non-conforme" class="fr-btn--tooltip fr-btn">Information contextuelle</button>
                         <span class="fr-tooltip fr-placement" id="tooltip-non-conforme" role="tooltip">La mention « non conforme » indique que le site n'a pas encore été audité, mais ne renseigne en rien l'accessibilité du service en lui-même.</span>
@@ -175,7 +175,7 @@ layout: default
                   <li><span class="fr-badge fr-text--xs">Accessibilité : non mentionnée</span></li>
                 {% endif %}
               {% endcapture %}
-              {% if page.accessibility_status and page.accessibility_status == 'conforme' %}
+              {% if page.accessibility_status and page.accessibility_status == 'totalement conforme' %}
                 {%- assign indicateurs_qualite_success = indicateurs_qualite_success | append: accessibilite_indicator -%}
               {% else %}
                 {%- assign indicateurs_qualite_warning = indicateurs_qualite_warning | append: accessibilite_indicator -%}


### PR DESCRIPTION
Actuellement, la fiche PassSport affiche un triste 
![image](https://github.com/user-attachments/assets/c70bee90-5e6d-4841-9ab0-9db34b6b3b9d)

Mais ça serait bien plus sympa en vert 
![image](https://github.com/user-attachments/assets/0806a28c-7205-43ad-b18a-bbeb56df142e)

