### PR TITLE
Ajoute une redirection pour Zacharie

### DIFF
--- a/content/_startups/zacharie.md
+++ b/content/_startups/zacharie.md
@@ -26,6 +26,7 @@ phases:
 events: []
 redirect_from:
   - /startups/tracabilite.gibier.sauvage
+  - /startups/tracabilite.gibier.sauvage.html
 ---
 ## Contexte
 


### PR DESCRIPTION
Intéressant /startups/tracabilite.gibier.sauvage bug en terme de redirection car c'est compris par les navigateurs par un fichier .sauvage et donc ça déclenche un téléchargement.