### PR TITLE
search: allow newlines

### DIFF
--- a/_layouts/recherche.html
+++ b/_layouts/recherche.html
@@ -120,7 +120,7 @@ layout: default
           title: "{{incubator.title}}",
           owner: "{{incubator.owner}}",
           content_url_encoded_markdown: "{{incubator.content_url_encoded_markdown}}",
-          short_description: "{{incubator.short_description | escape}}",
+          short_description: "{{incubator.short_description | strip_newlines | escape}}",
           website: "{{incubator.website}}",
           contact: "{{incubator.contact}}",
           address: "{{incubator.address}}",


### PR DESCRIPTION
La recherche était cassée lorsque des retours à la ligne sont présents dans la description de l'incubateur. C'est plus à la recherche de gérer ça plutôt qu'aux auteurs de garder ça en tête alors rajoute le filtre `strip_newlines` pour éviter tout problème.