### PR TITLE
Page startup : gère espaces pour sponsors

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -45,10 +45,10 @@ layout: default
           </p>
           <p>
             Ce service numérique est sponsorisé par
-            {% for sponsorId in page.sponsors %}
+            {%- for sponsorId in page.sponsors -%}
               {% assign sponsor = site.organisations | where: 'id', sponsorId | first %}
               {% if forloop.index > 1 %}, {% endif %}{{sponsor.name}}
-            {% endfor %}
+            {%- endfor -%}
           </p>
           <p>
             {% if page.contact %}


### PR DESCRIPTION
Évite d'avoir des espaces autour des noms des sponsors

> Ce service numérique est sponsorisé par Direction générale des infrastructures, des transports et des mobilités , Direction interministérielle du numérique , Ministère de la Transition Écologique , Secrétariat Général à la Planification Écologique

Visible sur https://beta.gouv.fr/startups/transport.html

Voir [doc Jekyll](https://shopify.github.io/liquid/basics/whitespace/)