### PR TITLE
feat(api): add authors.teams

### DIFF
--- a/api/v2.6/authors.json
+++ b/api/v2.6/authors.json
@@ -30,6 +30,13 @@ layout: null
                 {% endfor %}
             ]
             {% endif %}
+            {% if author.teams %}
+            , "teams": [
+                {% for team in author.teams %}
+                    "{{team}}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% endif %}
             {% if author.previously %}
             , "previously": [
                 {% for previous in author.previously %}

--- a/api/v2.6/teams.json
+++ b/api/v2.6/teams.json
@@ -1,0 +1,19 @@
+---
+layout: null
+---
+
+{ "links":
+    { "self": "{{ site.url }}/teams" }
+, "data":
+    [
+    {% for team in site.teams %}
+        { "id"        : "{{ team.id | remove: '/team/' }}"
+        , "type"      : "team"
+        , "name" : "{{ team.name }}"
+        , "mission" : "{{ team.mission | strip_newlines }}"
+        , "incubator" : "{{ team.incubator }}"
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    ]
+}


### PR DESCRIPTION
Ajout d'une clé `teams` dans `/api/authors.json` pour publier les équipes des membres