### PR TITLE
chore: retirer le lien espace-membre

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -21,9 +21,6 @@ shortcuts:
   - label: Blog
     external: true
     url: https://blog.beta.gouv.fr
-  - label: Espace Membre
-    external: true
-    url: https://espace-membre.incubateur.net
 fast:
   - label: Sélection au FAST
     target: /fast/sélection


### PR DESCRIPTION
## Modification des fiches

Attention, le contenu fiches startup, membre et incubateur **n'est plus modifiable directement sur GitHub**, tu dois exclusivement utiliser [l'espace-membre](https://espace-membre.incubateur.net).

Les changements sont publiés sur le site sous 24h max.
