### PR TITLE
fix(startup): fix analyse_risques

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -116,8 +116,12 @@ layout: default
                 {%- assign transparence_warning = transparence_warning | append: stats -%}
               {% endif %}
               {% capture link_risques %}
-              <li aria-disabled="{% if page.analyse_risques %}false{% else %}true{% endif %}">
-                Analyse de risque
+              <li>
+                <a class="fr-link fr-icon-warning-line fr-link--icon-left" href="#" role="link" 
+                    aria-disabled="{% if page.analyse_risques %}false{% else %}true{% endif %}"
+                >
+                  Analyse de risque
+                </a>
                 {% unless page.analyse_risques %}(non disponible){% endunless %}
               </li>
               {% endcapture %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -116,18 +116,12 @@ layout: default
                 {%- assign transparence_warning = transparence_warning | append: stats -%}
               {% endif %}
               {% capture link_risques %}
-              <li>
-                <a class="fr-link fr-icon-warning-line fr-link--icon-left"
-                  {% if page.analyse_risques_url %}href="{{page.analyse_risques_url }}"{% endif %}
-                  role="link" 
-                  aria-disabled="{% if page.analyse_risques_url %}false{% else %}true{% endif %}"
-                >
+              <li aria-disabled="{% if page.analyse_risques %}false{% else %}true{% endif %}">
                 Analyse de risque
-                {% unless page.analyse_risques_url %}(non disponible){% endunless %}
-                </a>
+                {% unless page.analyse_risques %}(non disponible){% endunless %}
               </li>
               {% endcapture %}
-              {% if page.analyse_risques_url %}
+              {% if page.analyse_risques %}
                 {%- assign transparence_success = transparence_success | append: link_risques  -%}
               {% else %}
                 {%- assign transparence_warning = transparence_warning | append: link_risques  -%}


### PR DESCRIPTION
correction de l'indicateur "analyse de risques". on devrait se baser sur le `bool` et a priori on ne veut pas diffuser l'URL de l'analyse, seulement savoir si elle a été effectuée ou pas.

fix #21010 

ex: https://beta.gouv.fr/startups/reva.html

VS https://betagouv-site-pr21011.osc-fr1.scalingo.io/startups/reva.html#

<img width="346" alt="Capture d’écran 2025-01-23 à 20 06 26" src="https://github.com/user-attachments/assets/40ce2a94-3b8b-4033-8148-a63118a72c5e" />

