### PR TITLE
feat: display standards evaluation results

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -84,9 +84,7 @@ RSpec/SpecFilePathFormat:
     - '**/spec/routing/**/*'
     - 'spec/lib/models/member_spec.rb'
     - 'spec/lib/models/startup_spec.rb'
-    - 'spec/plugins/community_spec.rb'
-    - 'spec/plugins/money_spec.rb'
-    - 'spec/plugins/startup_spec.rb'
+    - 'spec/plugins/**'
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -57,6 +57,53 @@ layout: default
             <a class="fr-link fr-link--icon-left fr-icon-mail-line" href="mailto:{{ site.email }}?subject={{ page.title | uri_escape }}%20sur%20beta.gouv.fr">Contacter l'incubateur</a></em>
             {% endif %}
           </p>
+
+          <div class="fr-my-2w startup-evaluation">
+            <h6>Standards de qualité</h6>
+
+            {% assign evaluation = site.evaluations[startup_id] %}
+
+            {% if evaluation %}
+              <p class="fr-text--sm fr-text--dimmed">
+                beta.gouv.fr définit des standards de qualité. Les
+                indicateurs suivants montrent comment l’équipe les met
+                en œuvre. Ces informations sont déclaratives.
+              </p>
+
+              <ul class="standards">
+                {% for result in evaluation["conformity"] %}
+                  <li>
+                    <span class="category">{{ result.first | humanize }}</span>
+                    {% if result.last %}
+                      <progress max="100" value="{{ result.last | round }}">{{ result.last | round }}</progress>
+                      <span class="score">
+                        {% if result.last == 100 %}
+                          <strong>{{ result.last | round }}%</strong>
+                        {% else %}
+                          {{ result.last | round }}%
+                        {% endif %}
+                      </span>
+                    {% else %}
+                      <span class="fr-text--dimmed blank">non renseigné</span>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p>
+                L'évaluation des standards de beta.gouv.fr n'a pas
+                encore été réalisée sur ce produit.
+              </p>
+            {% endif %}
+
+            <a
+                class="fr-text--sm"
+                href="https://standards.incubateur.net"
+                title="Le site des standards de beta.gouv.fr">
+              En savoir plus sur les standards
+            </a>
+          </div>
+
           {% unless phase.status == 'investigation' %}
           <div class="fr-py-1w">
             <b>Transparence</b>
@@ -135,7 +182,7 @@ layout: default
               {% endif %}
               {% capture link_risques %}
               <li>
-                <a class="fr-link fr-icon-warning-line fr-link--icon-left" href="#" role="link" 
+                <a class="fr-link fr-icon-warning-line fr-link--icon-left" href="#" role="link"
                     aria-disabled="{% if page.analyse_risques %}false{% else %}true{% endif %}"
                 >
                   Analyse de risque

--- a/_plugins/humanize.rb
+++ b/_plugins/humanize.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module BetaGouv
+    # a very naive humanize filter
+    module HumanizeFilter
+      def humanize(str)
+        str
+          .gsub(/[-_]/, ' ')
+          .downcase
+          .capitalize
+      end
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::BetaGouv::HumanizeFilter)

--- a/_plugins/load_startup_standards.rb
+++ b/_plugins/load_startup_standards.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'active_support'
+require 'net/http'
+
+# this extension fetches the index of all evaluations done on
+# standards.incubateur.net and stores them pre-build so the data can
+# be used with the startup page, similar to what the S3 image plugin
+# does in `load_s3_images.rb`.
+Jekyll::Hooks.register :site, :after_init do |site|
+  endpoint = ENV.fetch('STANDARDS_INCUBATEUR_API_ENDPOINT', nil)
+
+  # if we're running local don't bother
+  next if endpoint.blank?
+
+  Jekyll.logger.info "Fetching all evaluations from #{endpoint}..."
+
+  site.config['evaluations'] = JSON.parse(Net::HTTP.get(URI(endpoint), { Accept: 'application/json' }))
+end

--- a/assets/main.css
+++ b/assets/main.css
@@ -647,3 +647,48 @@ iframe.graph.h800 {
   margin-bottom: 2.5rem;
   margin-top: -1rem;
 }
+
+ul.standards {
+  list-style: none;
+  padding-left: 0;
+}
+
+ul.standards li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+ul.standards .category {
+  flex: 0 0 46%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+ul.standards progress {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 1.5rem;
+  border: 0;
+  background: #DDD;
+  border-radius: 3px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+progress::-moz-progress-bar, progress::-webkit-progress-value {
+  background: var(--background-action-high-blue-france);
+}
+
+ul.standards .score {
+  flex: 0 0 auto;
+  min-width: 2rem;
+  text-align: right;
+}
+
+.fr-text--dimmed {
+  color: #666;
+}

--- a/spec/plugins/humanize_spec.rb
+++ b/spec/plugins/humanize_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Jekyll::BetaGouv::HumanizeFilter do
+  matrix = {
+    'foo bar' => 'Foo bar',
+    'foo_bar' => 'Foo bar',
+    'foo-bar-baz' => 'Foo bar baz',
+    'foo_bar-baz bat man' => 'Foo bar baz bat man'
+  }
+
+  matrix.each do |str, human|
+    it "formats '#{str}' into '#{human}'" do
+      expect(template.humanize(str)).to eq human
+    end
+  end
+end


### PR DESCRIPTION
We first fetch the results via a pre-build hook in Jekyll, like we did for the S3 images, then conditionnally render the result.

Closes https://github.com/betagouv/beta.gouv.fr/issues/21347.
