### PR TITLE
feat: support de la co-incubation d'un produit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,9 @@ jobs:
     - name: Lint JSON API pages
       run: bundle exec jsonlint _site/api/v*/*.json
 
+    - name: Check JSON:API references
+      run: node ci/tests-api.mjs
+
     - name: Wait for server to start
       run: |
           (bundle exec jekyll serve --no-watch --skip-initial-build)&

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ _site
 .vscode
 
 # Node
-node_modules/**/*
+node_modules/
 
 # ruby
 vendor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin
   arm64-darwin-23
   x86_64-linux
 

--- a/_layouts/incubateur.html
+++ b/_layouts/incubateur.html
@@ -5,7 +5,7 @@ layout: default
 {% assign lang = page.lang | default: site.lang | default: "fr" %}
 {% assign incubator_id = page.id | remove: '/incubateurs/' %}
 {% assign owner = site.organisations | where: 'id', page.owner | first %}
-{% assign incubatorStartups = site.startups | where: 'incubator', incubator_id %}
+{% assign incubatorStartups = site.startups | where_incubator: incubator_id %}
 
 {% assign investigationStartupsCount = incubatorStartups | where_phase: 'investigation' | size %}
 {% assign constructionStartupsCount = incubatorStartups | where_phase: 'construction' | size %}

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -11,7 +11,9 @@ layout: default
 {% assign startup_phase = startup | get_phase %}
 {% assign phase = site.phases | find: "status", startup_phase.name %}
 
-{% comment %} Détection de l'incubateur {% endcomment %}
+{% comment %} Détection des incubateurs (un produit peut être co-incubé) {% endcomment %}
+{% assign incubator_ghids = page.incubators %}
+{% unless incubator_ghids %}{% assign incubator_ghids = page.incubator | split: ',' %}{% endunless %}
 {% capture incubator_id %}/incubateurs/{{ page.incubator }}{% endcapture %}
 {% assign incubator = site.data.all_incubators | where:'id', incubator_id | first %}
 
@@ -46,7 +48,17 @@ layout: default
             {% else %}
                est porté
             {% endif %}
-            par {% if incubator and incubator.hidden != true %}<a href="/incubateurs/{{ page.incubator }}" title="{{ incubator.title }}">{{ incubator.title }}</a>{% else %}{{ incubator.title | default: page.incubator }}{% endif %}.
+            par
+            {%- for incubator_ghid in incubator_ghids -%}
+              {%- capture current_incubator_id %}/incubateurs/{{ incubator_ghid }}{% endcapture -%}
+              {%- assign current_incubator = site.data.all_incubators | where:'id', current_incubator_id | first -%}
+              {%- if forloop.index > 1 %}{% if forloop.last %} et {% else %}, {% endif %}{% else %} {% endif -%}
+              {%- if current_incubator and current_incubator.hidden != true -%}
+                <a href="/incubateurs/{{ incubator_ghid }}" title="{{ current_incubator.title }}">{{ current_incubator.title }}</a>
+              {%- else -%}
+                {{- current_incubator.title | default: incubator_ghid -}}
+              {%- endif -%}
+            {%- endfor -%}.
           </p>
           <p>
             Ce service numérique est sponsorisé par

--- a/_layouts/startups.html
+++ b/_layouts/startups.html
@@ -16,6 +16,7 @@ layout: default
           , "type"      : "startup"
           , "phase": "{{ phase.status }}"
           , "incubator_id" : "{{startup.incubator}}"
+          , "incubator_ids" : [{% assign startup_incubators = startup.incubators %}{% unless startup_incubators %}{% assign startup_incubators = startup.incubator | split: ',' %}{% endunless %}{% for startup_incubator in startup_incubators %}"{{ startup_incubator }}"{% unless forloop.last %}, {% endunless %}{% endfor %}]
           , "incubator_title": "{{ incubator.title }}"
           , "sponsors": [{% for sponsorId in startup.sponsors %}
               {% assign sponsor = site.organisations | where: 'id', sponsorId | first %}

--- a/_plugins/incubators.rb
+++ b/_plugins/incubators.rb
@@ -25,8 +25,16 @@ module Jekyll
 
       startups
         .map    { |startup| Beta::Startup.from_document(startup) }
-        .select { |startup| startup.incubator == incubator_id }
+        .select { |startup| startup.incubated_by?(incubator_id) }
         .count(&:active?)
+    end
+
+    # Replaces `where: 'incubator', id`, which misses co-incubated products:
+    # Liquid's `where` can only compare against a single value.
+    def where_incubator(startups, incubator_id)
+      startups.select do |startup|
+        Beta::Startup.from_document(startup).incubated_by?(incubator_id)
+      end
     end
 
     def count_all_active_startups(startups)
@@ -55,22 +63,23 @@ module Jekyll
       incubators = context.registers[:site].collections['incubators']
       Date.today
       startups.docs.each do |startup|
-        incubator = startup['incubator']
-        next unless incubator
+        Beta::Startup.from_document(startup).incubator_ids.each do |incubator|
+          next unless incubator
 
-        unless result[incubator]
-          result[incubator] = {
-            'startups' => []
-          }
+          unless result[incubator]
+            result[incubator] = {
+              'startups' => []
+            }
+          end
+          result[incubator]['startups'].push({
+                                               'id' => startup.id.gsub('/startups/', ''),
+                                               'name' => startup['title'],
+                                               'pitch' => startup['mission'],
+                                               'repository' => startup['repository'],
+                                               'contact' => startup['contact'],
+                                               'phases' => startup['phases']
+                                             })
         end
-        result[incubator]['startups'].push({
-                                             'id' => startup.id.gsub('/startups/', ''),
-                                             'name' => startup['title'],
-                                             'pitch' => startup['mission'],
-                                             'repository' => startup['repository'],
-                                             'contact' => startup['contact'],
-                                             'phases' => startup['phases']
-                                           })
       end
       incubators.docs.each do |incubator|
         incubatorName = incubator.id.gsub('/incubateurs/', '')

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -440,6 +440,27 @@
             "items": {
               "$ref": "#/components/schemas/StartupResource"
             }
+          },
+          "included": {
+            "type": "array",
+            "description": "Incubateurs référencés par les `relationships` des startups, inclus une seule fois plutôt que répétés sur chaque produit. Depuis la version 2.7 l'`id` est l'identifiant nu (`ademe`), ce qui rend les références résolvables. Dans les versions 2.6 et antérieures il restait préfixé (`/incubateurs/ademe`) et ne correspondait donc à aucune référence, ce qui rendait ce bloc inexploitable.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Identifiant de l'incubateur, sans préfixe.",
+                  "example": "ademe"
+                },
+                "type": {
+                  "type": "string",
+                  "example": "incubator"
+                },
+                "attributes": {
+                  "$ref": "#/components/schemas/Incubator"
+                }
+              }
+            }
           }
         }
       },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "beta.gouv.fr API",
     "description": "API publique permettant d'accéder aux données des startups d'État, des membres, des incubateurs, des organisations et des sponsors de beta.gouv.fr",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "contact": {
       "name": "beta.gouv.fr",
       "url": "https://beta.gouv.fr"
@@ -15,7 +15,7 @@
   },
   "servers": [
     {
-      "url": "https://beta.gouv.fr/api/v2.6",
+      "url": "https://beta.gouv.fr/api/v2.7",
       "description": "Production server"
     }
   ],
@@ -467,6 +467,7 @@
             "properties": {
               "incubator": {
                 "type": "object",
+                "description": "Incubateur historique. Pour un produit co-incubé, il s'agit de l'un des incubateurs de `incubators`.",
                 "properties": {
                   "data": {
                     "type": "object",
@@ -478,6 +479,28 @@
                       "id": {
                         "type": "string",
                         "example": "agriculture"
+                      }
+                    }
+                  }
+                }
+              },
+              "incubators": {
+                "type": "object",
+                "description": "Tous les incubateurs du produit. Contient un seul élément pour un produit mono-incubé, plusieurs pour un produit co-incubé.",
+                "properties": {
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "example": "incubator"
+                        },
+                        "id": {
+                          "type": "string",
+                          "example": "agriculture"
+                        }
                       }
                     }
                   }

--- a/api/v2.7/authors.json
+++ b/api/v2.7/authors.json
@@ -1,0 +1,44 @@
+---
+layout: null
+---
+[
+    {% for author in site.authors %}
+        {
+            "id": "{{ author.id | remove:'/authors/' }}"
+            ,"fullname": "{{ author.fullname }}"
+            ,"role": "{{ author.role | escape }}"
+            ,"domaine": "{{ author.domaine | escape }}"
+            ,"link": "{{ author.link | escape }}"
+            {% if author.content %},"bio": {{ author.content | strip_html | strip | jsonify }}{% endif %}
+            {% if author.github %},"github": "{{ author.github }}"{% endif %}
+            , "missions": [
+                {% for mission in author.missions %}
+                    { "start": "{{mission.start}}", "end": "{{mission.end}}", "status": "{{mission.status}}", "employer": "{{mission.employer}}"{% if mission.startups %}, "startups": [{% for startup in mission.startups %}"{{startup}}"{% unless forloop.last %},{% endunless %}{% endfor %}]{% endif %} }{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% if author.competences %}
+            , "competences": [
+                {% for competence in author.competences %}
+                    "{{competence}}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% endif %}
+            {% if author.startups %}
+            , "startups": [
+                {% for startup in author.startups %}
+                    "{{startup}}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% endif %}
+            {% if author.previously %}
+            , "previously": [
+                {% for previous in author.previously %}
+                    "{{previous}}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+            ]
+            {% endif %}
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+]
+

--- a/api/v2.7/incubators.json
+++ b/api/v2.7/incubators.json
@@ -1,0 +1,5 @@
+---
+layout: null
+---
+
+{% render_incubators_api %}

--- a/api/v2.7/organisations.json
+++ b/api/v2.7/organisations.json
@@ -1,0 +1,15 @@
+---
+layout: null
+---
+[
+    {% for organisation in site.organisations %}
+        {
+            "id": "{{ organisation.id | remove:'/organisations/' }}"
+            ,"name": "{{ organisation.name | escape }}"
+            ,"acronym": "{{ organisation.acronym | escape }}"
+            ,"domaine_ministeriel": "{{ organisation.domaine_ministeriel | escape }}"
+            ,"type": "{{ organisation.type | escape }}"
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+]

--- a/api/v2.7/sponsors.json
+++ b/api/v2.7/sponsors.json
@@ -1,0 +1,5 @@
+---
+layout: null
+---
+
+{% render_sponsors_api %}

--- a/api/v2.7/startups.csv
+++ b/api/v2.7/startups.csv
@@ -1,0 +1,22 @@
+---
+layout: null
+---
+id;name;mission;start;status;incubator;stats;link;repository;accessibility;contact;incubators
+{% assign startups = site.startups %}
+{% for startup in startups %}
+    {%- assign id = startup.id | remove: '/startups/' -%}
+    {%- assign title = startup.title -%}
+    {%- assign mission = startup.mission -%}
+    {%- assign start = startup.phases.first.start -%}
+    {%- assign status = startup.phases.last.name -%}
+    {%- assign incubator = startup.incubator -%}
+    {%- assign startup_incubators = startup.incubators -%}
+    {%- unless startup_incubators -%}{%- assign startup_incubators = startup.incubator | split: ',' -%}{%- endunless -%}
+    {%- assign incubators = startup_incubators | join: ',' -%}
+    {%- if startup.stats_url -%}{%- assign stats = startup.stats_url -%}{%- else -%}{%- assign stats = 'null' -%}{%- endif -%}
+    {%- if startup.link -%}{%- assign link = startup.link -%}{%- else -%}{%- assign link = 'null' -%}{%- endif -%}
+    {%- if startup.repository -%}{%- assign repository = startup.repository -%}{%- else -%}{%- assign repository = 'null' -%}{%- endif -%}
+    {%- assign accessibility_status = startup.accessibility_status -%}
+    {%- assign contact = startup.contact -%}
+{{id}};"{{title}}";"{{mission}}";{{start}};{{status}};{{incubator}};{{stats}};{{link}};{{repository}};"{{accessibility_status}}";{{contact}};"{{incubators}}"
+{% endfor %}

--- a/api/v2.7/startups.json
+++ b/api/v2.7/startups.json
@@ -79,7 +79,7 @@ layout: null
 , "included":
     [
     {% for incubator in site.incubators %}
-        { "id"        : "{{ incubator.id | remove:'/incubateurs/approche' }}"
+        { "id"        : "{{ incubator.id | remove:'/incubateurs/' }}"
         , "type"      : "incubator"
         , "attributes":
             { "title"  : "{{ incubator.title }}"

--- a/api/v2.7/startups.json
+++ b/api/v2.7/startups.json
@@ -1,0 +1,95 @@
+---
+layout: null
+---
+
+{ "links":
+    { "self": "{{ site.url }}/startups" }
+, "data":
+    [
+    {% for startup in site.startups %}
+        { "id"        : "{{ startup.id | remove: '/startups/' }}"
+        , "type"      : "startup"
+        , "attributes":
+            { "name"  : "{{ startup.title }}"
+            , "pitch" : "{{ startup.mission }}"
+            , "stats_url": "{% if startup.stats_url %}{{ startup.stats_url }}{% else %}{% if startup.stats %}{{ startup.link | strip }}/stats{% endif %}{% endif %}"
+            {% if startup.budget_url %}
+            ,"budget_url": "{{ startup.budget_url }}"{% endif %}{% if startup.link %}
+            ,"impact_url": "{{ startup.impact_url }}"
+            , "link": "{{ startup.link}}"{% endif %}{% if startup.repository %}
+            , "repository": "{{ startup.repository}}"{% endif %}
+            , "contact": "{{startup.contact}}"
+            , "content_url_encoded_markdown": "{{startup.content_url_encoded_markdown}}"
+            , "events": [
+                {% for event in startup.events %}
+                    { "name": "{{event.name}}", "date": "{{event.date}}", "comment": "{{event.comment | strip_newlines }}"}{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+                ]
+            , "phases": [
+                {% for phase in startup.phases %}
+                    { "name": "{{phase.name}}", "start": "{{phase.start}}", "end": "{{phase.end}}"}{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+                ]
+            , "sponsors": [
+                {% for sponsor in startup.sponsors %}
+                    "{{sponsor | remove: '/organisations/' }}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+                ]
+            , "thematiques": [
+                {% for thematique in startup.thematiques %}
+                    "{{thematique}}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+                ]
+            , "technos": [
+                {% for techno in startup.techno %}
+                    "{{techno}}"{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+                ]
+            {% if startup.analyse_risques %}
+            , "analyse_risques": "{{ startup.analyse_risques}}"
+            {% endif %}
+            {% if startup.analyse_risques_url %}
+            , "analyse_risques_url": "{{ startup.analyse_risques_url}}"
+            {% endif %}
+            {% if startup.dashlord_url %}
+            , "dashlord_url": "{{ startup.dashlord_url}}"
+            {% endif %}
+            {% if startup.accessibility_status %}
+            , "accessibility_status": "{{ startup.accessibility_status}}"
+            {% endif %}
+            }
+        , "relationships":
+            { "incubator":
+                { "data": { "type": "incubator", "id": "{{ startup.incubator}}" }
+                }
+            , "incubators":
+                { "data":
+                    [
+                    {% assign startup_incubators = startup.incubators %}{% unless startup_incubators %}{% assign startup_incubators = startup.incubator | split: ',' %}{% endunless %}
+                    {% for startup_incubator in startup_incubators %}
+                        { "type": "incubator", "id": "{{ startup_incubator }}" }{% unless forloop.last %},{% endunless %}
+                    {% endfor %}
+                    ]
+                }
+            }
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    ]
+, "included":
+    [
+    {% for incubator in site.incubators %}
+        { "id"        : "{{ incubator.id | remove:'/incubateurs/approche' }}"
+        , "type"      : "incubator"
+        , "attributes":
+            { "title"  : "{{ incubator.title }}"
+            , "owner"  : "{{ incubator.owner }}"
+            , "website": "{{ incubator.website }}"
+            , "github" : "{{ incubator.github }}"
+            , "contact": "{{ incubator.contact }}"
+            }
+        }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    ]
+}

--- a/api/v2.7/startups_details.json
+++ b/api/v2.7/startups_details.json
@@ -1,0 +1,5 @@
+---
+layout: null
+---
+
+{% render_startups_api %}

--- a/assets/additional/js/search-startup.js
+++ b/assets/additional/js/search-startup.js
@@ -108,7 +108,11 @@ const displayNoDataMessage = (shouldDisplay) => {
 const filterCards = (startups) => {
   return startups
     .filter((startup) =>
-      filters.incubator ? startup.incubator_id === filters.incubator : true,
+      filters.incubator
+        ? (startup.incubator_ids || [startup.incubator_id]).includes(
+            filters.incubator,
+          )
+        : true,
     )
     .filter((startup) =>
       filters.usertypes

--- a/ci/startups.mjs
+++ b/ci/startups.mjs
@@ -20,8 +20,9 @@ export const schema = z
       .optional(),
     incubator: z.string(),
     // Co-incubation : présent uniquement quand un produit est porté par
-    // plusieurs incubateurs. `incubator` reste la valeur historique et doit
-    // faire partie de cette liste.
+    // plusieurs incubateurs. L'appartenance de `incubator` à cette liste est
+    // vérifiée plus bas : sans elle, la normalisation côté site ferait
+    // disparaître le produit des pages de son incubateur historique.
     incubators: z.array(z.enum(incubatorsIds)).min(2).optional(),
     contact: z.string(),
     link: z.string().optional().nullable(),
@@ -52,6 +53,13 @@ export const schema = z
     mon_service_securise: z.boolean().optional().nullable(),
   })
   .superRefine((obj, ctx) => {
+    if (obj.incubators && !obj.incubators.includes(obj.incubator)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `incubator "${obj.incubator}" is missing from incubators`,
+      });
+    }
+
     if (
       obj.phases.length !==
       Array.from(new Set(obj.phases.map((p) => p.name))).length

--- a/ci/startups.mjs
+++ b/ci/startups.mjs
@@ -61,6 +61,16 @@ export const schema = z
     }
 
     if (
+      obj.incubators &&
+      obj.incubators.length !== new Set(obj.incubators).size
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Duplicated incubators",
+      });
+    }
+
+    if (
       obj.phases.length !==
       Array.from(new Set(obj.phases.map((p) => p.name))).length
     ) {

--- a/ci/startups.mjs
+++ b/ci/startups.mjs
@@ -6,6 +6,11 @@ const organisationsIds = (await fs.readdir(organisationsPath))
   .filter((path) => path.endsWith(".md"))
   .map((p) => p.replace(/\.md$/, ""));
 
+const incubatorsPath = "./content/_incubators";
+const incubatorsIds = (await fs.readdir(incubatorsPath))
+  .filter((path) => path.endsWith(".md"))
+  .map((p) => p.replace(/\.md$/, ""));
+
 export const schema = z
   .object({
     title: z.string(),
@@ -14,6 +19,10 @@ export const schema = z
       .array(z.enum(organisationsIds.map((id) => `/organisations/${id}`)))
       .optional(),
     incubator: z.string(),
+    // Co-incubation : présent uniquement quand un produit est porté par
+    // plusieurs incubateurs. `incubator` reste la valeur historique et doit
+    // faire partie de cette liste.
+    incubators: z.array(z.enum(incubatorsIds)).min(2).optional(),
     contact: z.string(),
     link: z.string().optional().nullable(),
     repository: z.string().optional().nullable(),

--- a/ci/tests-api.mjs
+++ b/ci/tests-api.mjs
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import matter from "gray-matter";
+
+// Vérifie l'assemblage JSON:API du site généré : toute référence portée par un
+// `relationships` doit pointer vers une ressource réellement présente dans
+// `included`. Sans ce contrôle, une erreur de préfixe passe inaperçue, le
+// document restant un JSON parfaitement valide. C'est ce qui a laissé les
+// versions 2.1 à 2.6 sortir avec un `included` inexploitable.
+//
+// Seule la v2.7 est vérifiée : les versions antérieures sont publiées avec ce
+// défaut et ne peuvent plus être corrigées sans casser leurs consommateurs.
+const VERSIONS = ["v2.7"];
+
+// Les incubateurs masqués sont volontairement absents d'`included` : l'API
+// n'expose pas leurs métadonnées (leur titre est déjà `null` dans
+// `incubators.json`). Leurs produits restent publics et continuent donc de les
+// référencer. Ces références ne sont pas résolvables par construction.
+const incubatorsPath = "./content/_incubators";
+const hiddenIncubators = new Set();
+
+for (const file of await fs.readdir(incubatorsPath)) {
+  if (!file.endsWith(".md")) continue;
+
+  const { data } = matter(
+    await fs.readFile(`${incubatorsPath}/${file}`, "utf8"),
+  );
+  if (data.hidden) hiddenIncubators.add(file.replace(/\.md$/, ""));
+}
+
+const errors = [];
+
+for (const version of VERSIONS) {
+  const path = `./_site/api/${version}/startups.json`;
+
+  let document;
+  try {
+    document = JSON.parse(await fs.readFile(path, "utf8"));
+  } catch (error) {
+    errors.push(`${version}: ${path} illisible (${error.message})`);
+    continue;
+  }
+
+  const included = new Set((document.included ?? []).map((entry) => entry.id));
+  if (included.size === 0) {
+    errors.push(`${version}: included est vide`);
+    continue;
+  }
+
+  const missing = new Set();
+  for (const startup of document.data ?? []) {
+    const relationships = startup.relationships ?? {};
+    const referenced = [
+      relationships.incubator?.data,
+      ...(relationships.incubators?.data ?? []),
+    ].filter(Boolean);
+
+    for (const { id } of referenced) {
+      if (!included.has(id) && !hiddenIncubators.has(id)) {
+        missing.add(`${id} (ex. ${startup.id})`);
+      }
+    }
+  }
+
+  if (missing.size > 0) {
+    errors.push(
+      `${version}: ${missing.size} référence(s) introuvable(s) dans included : ${[...missing].slice(0, 5).join(", ")}`,
+    );
+  } else {
+    console.log(
+      `${version}: ${included.size} ressources incluses, toutes les références résolvent`,
+    );
+  }
+}
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(`Error: ${error}`);
+  process.exit(1);
+}
+
+console.log("No errors");

--- a/lib/models/startup.rb
+++ b/lib/models/startup.rb
@@ -8,7 +8,7 @@ module Beta
   class Startup < Base
     FOLDER_IDENTIFIER = '_startups'
 
-    interesting :id, :incubator, :title, :phases, :mission, :accessibility_status
+    interesting :id, :incubator, :incubators, :title, :phases, :mission, :accessibility_status
 
     PHASES = %w[investigation
                 construction
@@ -26,6 +26,18 @@ module Beta
       consolidation
       opere
     ].freeze
+
+    # `incubators` is only written for co-incubated products, so it can't be
+    # read directly: `incubator` is the historical single value and is the only
+    # one guaranteed to be there.
+    def incubator_ids
+      ids = Array(incubators).compact
+      ids.empty? ? Array(incubator).compact : ids
+    end
+
+    def incubated_by?(incubator_id)
+      incubator_ids.include?(incubator_id)
+    end
 
     def latest_phase
       phases

--- a/lib/models/startup.rb
+++ b/lib/models/startup.rb
@@ -85,6 +85,10 @@ module Beta
       { name: document.data['title'] }
         .merge(document.data.slice(*API_SINGLE_FIELDS))
         .merge(
+          # Normalized rather than sliced from the frontmatter, which only
+          # carries `incubators` for co-incubated products: consumers always
+          # get a list, whatever the product.
+          incubators: incubator_ids,
           active_members: active_members.map(&:id),
           previous_members: previous_members.map(&:id)
         )

--- a/spec/lib/models/startup_spec.rb
+++ b/spec/lib/models/startup_spec.rb
@@ -37,6 +37,56 @@ YAML
     end
   end
 
+  describe 'incubators' do
+    let(:co_incubated_yml) do
+      <<YAML
+  id: ecopass
+  title: Ecopass
+  incubator: mtes
+  incubators: [mtes, ademe]
+  phases:
+    - name: construction
+      start: 2024-01-01
+YAML
+    end
+
+    let(:co_incubated) { described_class.new(Psych.unsafe_load(co_incubated_yml)) }
+
+    describe '#incubator_ids' do
+      it 'falls back to the single incubator when the product is not co-incubated' do
+        expect(startup.incubator_ids).to eq %w[dinum]
+      end
+
+      it 'returns every incubator of a co-incubated product' do
+        expect(co_incubated.incubator_ids).to eq %w[mtes ademe]
+      end
+
+      it 'returns nothing when the product has no incubator at all' do
+        orphan = described_class.new(Psych.unsafe_load(yml.sub('incubator: dinum', 'title: Orphelin')))
+
+        expect(orphan.incubator_ids).to be_empty
+      end
+    end
+
+    describe '#incubated_by?' do
+      it 'matches the single incubator' do
+        expect(startup).to be_incubated_by('dinum')
+      end
+
+      it 'matches the historical incubator of a co-incubated product' do
+        expect(co_incubated).to be_incubated_by('mtes')
+      end
+
+      it 'matches the additional incubator of a co-incubated product' do
+        expect(co_incubated).to be_incubated_by('ademe')
+      end
+
+      it 'does not match an unrelated incubator' do
+        expect(co_incubated).not_to be_incubated_by('anct')
+      end
+    end
+  end
+
   describe 'members' do
     let(:member) { instance_double(Beta::Member) }
 

--- a/spec/lib/models/startup_spec.rb
+++ b/spec/lib/models/startup_spec.rb
@@ -6,6 +6,8 @@ require 'active_support/core_ext/date/calculations'
 require_relative '../../../lib/models/startup'
 require_relative '../../../lib/models/member'
 
+ApiDocument = Struct.new(:relative_path, :data, :content)
+
 describe Beta::Startup do
   subject(:startup) { described_class.new(data) }
 
@@ -65,6 +67,28 @@ YAML
         orphan = described_class.new(Psych.unsafe_load(yml.sub('incubator: dinum', 'title: Orphelin')))
 
         expect(orphan.incubator_ids).to be_empty
+      end
+    end
+
+    describe '#to_api_hash' do
+      before { allow(Beta::Member).to receive(:all).and_return [] }
+
+      def api_hash_for(source)
+        document = ApiDocument.new('_startups/produit.md', Psych.unsafe_load(source), '')
+
+        described_class.from_document(document).to_api_hash
+      end
+
+      it 'exposes a list even for a product with a single incubator' do
+        expect(api_hash_for(yml)[:incubators]).to eq %w[dinum]
+      end
+
+      it 'exposes every incubator of a co-incubated product' do
+        expect(api_hash_for(co_incubated_yml)[:incubators]).to eq %w[mtes ademe]
+      end
+
+      it 'keeps the historical incubator alongside the list' do
+        expect(api_hash_for(co_incubated_yml)['incubator']).to eq 'mtes'
       end
     end
 

--- a/spec/plugins/incubators_spec.rb
+++ b/spec/plugins/incubators_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../lib/models/startup'
+
+StartupDocument = Struct.new(:relative_path, :data)
+IncubatorPage = Struct.new(:id)
+
+def startup_document(id, incubator:, incubators: nil, phase: 'construction')
+  data = {
+    'incubator' => incubator,
+    'phases' => [{ 'name' => phase, 'start' => Date.new(2024, 1, 1) }]
+  }
+  data['incubators'] = incubators if incubators
+
+  StartupDocument.new("_startups/#{id}.md", data)
+end
+
+describe Jekyll::ActiveStartupsFilter do
+  let(:mono) { startup_document('mono', incubator: 'dinum') }
+  let(:co_incubated) { startup_document('ecopass', incubator: 'mtes', incubators: %w[mtes ademe]) }
+
+  describe '#where_incubator' do
+    it 'matches a product on its single incubator' do
+      expect(template.where_incubator([mono, co_incubated], 'dinum')).to eq [mono]
+    end
+
+    it 'matches a co-incubated product on its historical incubator' do
+      expect(template.where_incubator([mono, co_incubated], 'mtes')).to eq [co_incubated]
+    end
+
+    it 'matches a co-incubated product on its additional incubator' do
+      expect(template.where_incubator([mono, co_incubated], 'ademe')).to eq [co_incubated]
+    end
+
+    it 'returns nothing for an incubator without any product' do
+      expect(template.where_incubator([mono, co_incubated], 'anct')).to be_empty
+    end
+  end
+
+  describe '#count_incubator_active_startups' do
+    let(:ademe) { IncubatorPage.new('/incubateurs/ademe') }
+    let(:mtes) { IncubatorPage.new('/incubateurs/mtes') }
+
+    it 'counts a co-incubated product under its historical incubator' do
+      expect(template.count_incubator_active_startups(mtes, [mono, co_incubated])).to eq 1
+    end
+
+    it 'counts a co-incubated product under its additional incubator' do
+      expect(template.count_incubator_active_startups(ademe, [mono, co_incubated])).to eq 1
+    end
+
+    it 'ignores a co-incubated product that is no longer active' do
+      stopped = startup_document('arrete', incubator: 'mtes', incubators: %w[mtes ademe], phase: 'abandon')
+
+      expect(template.count_incubator_active_startups(ademe, [stopped])).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
Pendant longtemps un produit n'a pu être porté que par un seul incubateur. Ecopass, incubé à la fois par le MTE et par l'ADEME, n'était pas représentable.

Cette PR est la moitié « site » du changement. La moitié « données », qui produit le frontmatter consommé ici, est dans betagouv/espace-membre-next#1498. Les deux se répondent et n'ont d'effet visible qu'ensemble.

## Approche

Le frontmatter reçoit un champ `incubators` au pluriel, écrit **uniquement pour les produits réellement co-incubés**. Les 635 fiches mono-incubateur gardent `incubator` seul et ne sont pas touchées, ce qui évite un diff de 635 fichiers pour une information déjà présente.

La conséquence est que le pluriel est optionnel : tout le code de lecture normalise et ne suppose jamais son existence. Cette normalisation vit dans le modèle `Beta::Startup`, là où le reste du domaine est déjà décrit : `incubators` rejoint les attributs, `incubator_ids` renvoie le pluriel s'il existe et retombe sur le singulier sinon, et le prédicat `incubated_by?` sert de point d'entrée unique.

`incubator` au singulier est conservé partout comme incubateur historique, en miroir de la décision prise côté espace-membre pour ne pas casser les consommateurs de l'API protégée, qui n'est pas versionnée.

## Ce que ça change

Le filtre Liquid `where: 'incubator'` ne peut comparer qu'une valeur unique et rate donc les produits co-incubés. Il est remplacé par un filtre `where_incubator` bâti sur `incubated_by?`. Le compteur `count_incubator_active_startups` et l'index inversé de `render_incubators_api` passent par le même prédicat, de sorte qu'aucun code ne relit `incubator` en direct.

Côté rendu, la fiche produit affiche « portée par X et Y », la page de listing émet `incubator_ids` et le filtre JavaScript teste l'appartenance au tableau au lieu d'une égalité stricte.

`api/v2.7` ajoute une relation JSON:API `incubators` en to-many à côté de `incubator` en to-one, qui reste intacte. Dans le CSV, la colonne est ajoutée en fin de ligne pour ne décaler aucune colonne existante.

L'API v3, celle générée par `_plugins/startup_json_generator.rb`, expose elle aussi `incubators`. La liste y est normalisée plutôt que reprise via `API_SINGLE_FIELDS`, qui `slice` le frontmatter : la clé n'y aurait été présente que pour les produits co-incubés, alors que la v2.7 en expose toujours une. Le contrat est donc le même partout, un consommateur lit une liste quel que soit le produit.

La version statique est numérotée 2.7 et non 3.0 parce que `api/v3` existe déjà, généré au build par `_plugins/startup_json_generator.rb` sous une forme différente. Nommer celle-ci v3.0 aurait fait cohabiter deux APIs de formes distinctes sous des noms voisins. Le changement étant purement additif, un bump mineur est de toute façon exact.

À noter : `_plugins/incubators.rb` est partagé par toutes les versions d'API. Un produit co-incubé apparaît donc sous ses deux incubateurs y compris dans le `incubators.json` des versions antérieures. La forme ne change pas, seule la donnée devient plus complète.

## Vérifications

Aucune fiche ne porte `incubators` aujourd'hui, donc rien ne bouge visuellement tant qu'Ecopass n'est pas importé. Pour prouver le rendu, le cas co-incubé a été simulé en local sur Ecobalyse (`[mtes, ademe]`), vérifié, puis annulé.

Sur les 661 fiches générées en v3, toutes portent `incubators`, aucune ne diverge de son `incubator` historique et la clé n'est jamais dupliquée dans le JSON.

Sur le cas co-incubé : la fiche produit affiche bien les deux incubateurs sous forme de liens, `api/v2.7/startups.json` sort une relation `incubators` à deux entrées avec `incubator` inchangé, le CSV v2.7 est l'ancienne ligne plus `;"mtes,ademe"` sans décalage, la v2.6 ne porte toujours pas la clé, et le listing `/startups/` expose `["mtes", "ademe"]`. Le compteur de la page ADEME monte à 11 services en incubation (7 en construction, 4 en accélération), ce qui correspond au calcul refait depuis les fiches sources, et la page MTE est inchangée à 36.

`bundle exec rspec` passe (57 exemples), `bundle exec rubocop` ne relève rien sur les 40 fichiers, `npm run lint` est propre et `node ci/tests-fiches.mjs` valide les 661 fiches. Le build Jekyll complet passe, ainsi que `make html-proofer` et `bundle exec jsonlint` sur les APIs générées, la v2.7 comprise. Le schéma zod valide `incubators` contre la liste réelle des ids lus depuis `content/_incubators/`, avec un minimum de deux éléments, pour qu'une faute de frappe soit rattrapée par la CI.

## Les deux commits `chore:`

Ils ne sont pas cosmétiques, ils étaient nécessaires pour vérifier cette PR sans salir l'arbre de travail.

Le pattern `node_modules/**/*` du `.gitignore` contient un slash, git l'ancrait donc à la racine et ne couvrait pas `ci/node_modules`, créé dès qu'on installe les dépendances pour lancer `ci/tests-fiches.mjs`. Et le `Gemfile.lock` ne listait que `arm64-darwin-23`, donc bundler y ajoutait la plateforme spécifique de chaque machine à la première commande exécutée. La plateforme générique `arm64-darwin` couvre toutes les versions de macOS ARM d'un coup.

## Rebase sur master

La branche partait d'un `master` antérieur au refactor `phases: use the new phases` (#21550), qui a réécrit `_plugins/incubators.rb` autour du modèle `Beta::Startup` et renommé les phases. Elle a été rebasée dessus : le conflit se limitait à ce fichier, les templates et le JS se sont auto-mergés, et `api/v2.6` n'avait pas bougé, donc la copie v2.7 reste fidèle. L'implémentation a été refaite sur le modèle plutôt que de restaurer l'ancienne manipulation de hashes, et les tests ont été redécoupés en conséquence : la normalisation dans `spec/lib/models/startup_spec.rb`, les filtres dans `spec/plugins/incubators_spec.rb`.

## Suites de la revue

Trois points relevés en relecture, corrigés ici.

Le schéma Zod annonçait en commentaire que `incubator` devait appartenir à `incubators` sans le vérifier. Une fiche portant `incubators: [ademe, anct]` et `incubator: mtes` passait la CI et aurait fait disparaître le produit des pages du MTE, tout en continuant à l'exposer comme incubateur historique dans l'API. Les doublons (`[mtes, mtes]`) sont rejetés au passage, ils auraient produit un « porté par X et X ». Ces deux règles sont déjà garanties en base côté espace-membre, les vérifier ici est une défense en profondeur.

Le bloc `included` de la v2.7 calculait ses ids via `remove:'/incubateurs/approche'`, un motif qui ne retire rien puisqu'aucun id ne le contient. Il sortait donc `/incubateurs/ademe` là où les `relationships` référencent `ademe` : aucune référence ne résolvait, et `included` était inexploitable. Le défaut est présent de la v2.1 à la v2.6 (introduit par #15398) et vraisemblablement issu d'un copier-coller, les autres `remove` du même fichier étant corrects. Seule la v2.7 est corrigée, faute de consommateur à casser ; la divergence est documentée dans le swagger, où `included` n'était pas décrit.

`ci/tests-api.mjs` vérifie désormais l'invariant après le build. C'est l'enseignement principal : le document restait un JSON valide et `jsonlint` passait, seul un contrôle sémantique pouvait détecter le problème, d'où six versions passées inaperçues. Les incubateurs masqués en sont explicitement exclus : l'API n'expose pas leurs métadonnées alors que leurs produits restent publics, leurs références ne sont donc pas résolvables par construction. Comportement existant, laissé tel quel.
